### PR TITLE
Prevent loading simplelayout if there is no simlelayout container.

### DIFF
--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -13,7 +13,13 @@
       simplelayout: null,
       init: function(callback) {
         var self = this;
-        var settings = $(this.settings.source).data("slSettings") || {};
+        var source = $(this.settings.source);
+
+        if (source.length === 0){
+          return;
+        }
+
+        var settings = source.data("slSettings") || {};
         this.settings = $.extend(this.settings, settings);
         this.loadComponents(function(components) {
           self.simplelayout = new global.Simplelayout({source: self.settings.source});


### PR DESCRIPTION
It no longer tries to load the `sl-ajax-addable-blocks-view` on non simplelayout pages. 

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module ftw.simplelayout.browser.ajax.addable_blocks_view, line 23, in __call__
  Module ftw.simplelayout.browser.ajax.addable_blocks_view, line 28, in addable_blocks
TypeError: ('Could not adapt', <PloneSite at /Plone>, <InterfaceClass Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes>)
```