### PR TITLE
lawgiver: map permissions.

### DIFF
--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -11,6 +11,7 @@
     <include package=".browser" />
     <include package=".contents" />
     <include file="behaviors.zcml" />
+    <include file="lawgiver.zcml" zcml:condition="installed ftw.lawgiver" />
 
     <genericsetup:registerProfile
         name="default"

--- a/ftw/simplelayout/lawgiver.zcml
+++ b/ftw/simplelayout/lawgiver.zcml
@@ -1,0 +1,20 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:lawgiver="http://namespaces.zope.org/lawgiver"
+    i18n_domain="ftw.simplelayout">
+
+    <include package="ftw.lawgiver" file="meta.zcml" />
+
+    <lawgiver:map_permissions
+        action_group="add"
+        permissions="ftw.simplelayout: Add ContentPage"
+        />
+
+    <lawgiver:map_permissions
+        action_group="edit"
+        permissions="ftw.simplelayout: Add File,
+                     ftw.simplelayout: Add ListingBlock,
+                     ftw.simplelayout: Add TextBlock"
+        />
+
+</configure>


### PR DESCRIPTION
Adding a page requires the "add" action group.

Adding files, listingblocks and textblocks requires the "edit" action group,
becuase it is in fact considered editing the content of the page.