### PR TITLE
Implement copy support for simplelayout pages.

### DIFF
--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -40,4 +40,9 @@
         factory=".configuration.BlockConfiguration"
         />
 
+    <subscriber
+        for="ftw.simplelayout.interfaces.ISimplelayoutBlock
+             zope.lifecycleevent.IObjectCopiedEvent"
+        handler=".handlers.update_page_state" />
+
 </configure>

--- a/ftw/simplelayout/handlers.py
+++ b/ftw/simplelayout/handlers.py
@@ -1,0 +1,44 @@
+from ftw.simplelayout.interfaces import IPageConfiguration
+from ftw.simplelayout.interfaces import ISimplelayout
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
+from plone.uuid.interfaces import IUUID
+import json
+
+
+def unwrap_persistence(conf):
+    """Unwrap recursice persistent page state
+    """
+    def unwrap(data):
+        if isinstance(data, PersistentMapping):
+            data = dict(data)
+            for key, value in data.items():
+                data[key] = unwrap(value)
+        elif isinstance(data, PersistentList):
+            return list(map(unwrap, data))
+        else:
+            # Usually we got basestrings, or integer here, so do nothing.
+            pass
+        return data
+    return unwrap(conf)
+
+
+def update_page_state(block, event):
+    """Update the uid of the new created block in the page state.
+    block: new block
+    event.original: origin of the copy event - usually the simplelayout page"""
+
+    # Only update page state, if the original object is a Simplelayout page.
+    if not ISimplelayout.providedBy(event.original):
+        return
+
+    origin_block_uid = IUUID(event.original.get(block.id))
+    page_config = IPageConfiguration(block.aq_parent)
+    page_state = unwrap_persistence(page_config.load())
+
+    new_block_uid = IUUID(block)
+    new_page_state = json.loads(
+        json.dumps(page_state).replace(origin_block_uid,
+                                       new_block_uid))
+
+    page_config.store(new_page_state)

--- a/ftw/simplelayout/tests/test_copy_contentpage.py
+++ b/ftw/simplelayout/tests/test_copy_contentpage.py
@@ -1,0 +1,74 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.interfaces import IPageConfiguration
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+from ftw.simplelayout.testing import SimplelayoutTestCase
+from ftw.testbrowser import Browser
+from plone.uuid.interfaces import IUUID
+import transaction
+
+
+class TestCopySimplelayoutPage(SimplelayoutTestCase):
+
+    layer = FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.setup_sample_block_fti(self.portal)
+        self.setup_block_views()
+
+        self.page = create(Builder('sl content page'))
+        self.block_left = create(Builder('sample block').within(self.page))
+        self.block_right = create(Builder('sample block').within(self.page))
+        self.block_below = create(Builder('sample block').within(self.page))
+
+        self.page_state = {
+            "default": [
+                {"cols": [
+                    {"blocks": [
+                        {"uid": IUUID(self.block_left)}
+                    ]},
+                    {"blocks": [
+                        {"uid": IUUID(self.block_right)}
+                    ]},
+                ]},
+                {"cols": [
+                    {"blocks": [
+                        {"uid": IUUID(self.block_below)
+                         }
+                    ]}
+                ]}
+            ]
+        }
+
+        IPageConfiguration(self.page).store(self.page_state)
+        transaction.commit()
+
+    def assertPageLayout(self, page):
+        browser = Browser()
+        with browser(self.layer['app']):
+            browser.login().visit(page)
+
+            self.assertEquals(
+                1,
+                len(browser.css('.sl-layout:first-child > .sl-column:first-child > .sl-block')),
+                'Expect one block in first column of the first layout.')
+
+            self.assertEquals(
+                1,
+                len(browser.css('.sl-layout:first-child > .sl-column:nth-child(2) > .sl-block')),
+                'Expect one block in second column of the first layout.')
+
+            self.assertEquals(
+                1,
+                len(browser.css('.sl-layout:nth-child(2) .sl-block')),
+                'Expect one block in second second layout.')
+
+    def test_uids_in_block_state_are_updated_after_copy(self):
+        copy = self.portal.manage_copyObjects([self.page.id])
+        self.portal.manage_pasteObjects(copy)
+        transaction.commit()
+        self.assertPageLayout(self.page)
+
+        newpage = self.portal.get('copy_of_' + self.page.id)
+        self.assertPageLayout(newpage)


### PR DESCRIPTION
After a simplelayout page has copied, update the PageState with the new block uids. 
So the layout and blocks remain on their position. 