### PR TITLE
Bad response for components breaks simplelayout.

### DIFF
--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -29,7 +29,15 @@
         });
 
       },
-      loadComponents: function(callback) { $.get(this.settings.addableBlocksEndpoint).done(callback); },
+      loadComponents: function(callback) {
+        $.get(this.settings.addableBlocksEndpoint).done(function(data, textStatus, request) {
+          var contentType = request.getResponseHeader("Content-Type");
+          if(contentType.indexOf("application/json") < 0) {
+            throw new Error("Bad response [content-type: " + contentType + "]");
+          }
+          callback(data);
+        });
+      },
       saveState: function() {
         var state = {};
         $(".sl-simplelayout").each(function(manIdx, manager) {


### PR DESCRIPTION
Check for response content type header. Accept only ```application/json```.
An error would look like this: ```Uncaught Error: Bad response
[content-type: text/html;charset=utf-8]```