### PR TITLE
Uploading images in filelistingblock will create a file instead an image

### DIFF
--- a/ftw/simplelayout/browser/configure.zcml
+++ b/ftw/simplelayout/browser/configure.zcml
@@ -46,4 +46,9 @@
              *"
         />
 
+    <adapter
+        factory=".uploadcapable.FileListingQuickUploadCapableFileFactory"
+        for="ftw.simplelayout.contents.interfaces.IFileListingBlock"
+        provides="collective.quickupload.interfaces.IQuickUploadFileFactory"
+        />
 </configure>

--- a/ftw/simplelayout/browser/uploadcapable.py
+++ b/ftw/simplelayout/browser/uploadcapable.py
@@ -1,0 +1,12 @@
+from collective.quickupload.browser import uploadcapable
+
+
+class FileListingQuickUploadCapableFileFactory(
+        uploadcapable.QuickUploadCapableFileFactory):
+
+    def __call__(self, filename, title, description, content_type,
+                 data, portal_type):
+
+        portal_type = "File"
+        return super(FileListingQuickUploadCapableFileFactory, self).__call__(
+            filename, title, description, content_type, data, portal_type)

--- a/ftw/simplelayout/tests/test_uploadcapable.py
+++ b/ftw/simplelayout/tests/test_uploadcapable.py
@@ -1,0 +1,38 @@
+from collective.quickupload.interfaces import IQuickUploadFileFactory
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.browser import uploadcapable
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
+from Products.ATContentTypes.interfaces.file import IATFile
+from unittest2 import TestCase
+from zope.component import queryAdapter
+
+
+class TestUploadCapableAdapter(TestCase):
+
+    layer = FTW_SIMPLELAYOUT_CONTENT_TESTING
+
+    def setUp(self):
+        super(TestUploadCapableAdapter, self).setUp()
+        self.portal = self.layer['portal']
+        self.page = create(Builder('sl content page').titled(u'A page'))
+        self.filelistingblock = create(Builder('sl listingblock')
+                                       .within(self.page))
+
+    def test_adapter_registration_on_listingblock(self):
+        adapter = queryAdapter(self.filelistingblock, IQuickUploadFileFactory)
+        self.assertIsNotNone(adapter)
+        self.assertIsInstance(
+            adapter, uploadcapable.FileListingQuickUploadCapableFileFactory)
+
+    def test_portal_type_is_alway_a_file(self):
+        adapter = queryAdapter(self.filelistingblock, IQuickUploadFileFactory)
+        # creates
+        adapter('test.jpg', None, None, None, None, None)
+        contents = self.filelistingblock.listFolderContents()
+
+        self.assertNotEqual(
+            [], contents,
+            "It was not possible to create the file. Please check the adapter")
+
+        self.assertTrue(IATFile.providedBy(contents[0]))

--- a/ftw/simplelayout/tests/test_uploadcapable.py
+++ b/ftw/simplelayout/tests/test_uploadcapable.py
@@ -3,7 +3,6 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.simplelayout.browser import uploadcapable
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
-from Products.ATContentTypes.interfaces.file import IATFile
 from unittest2 import TestCase
 from zope.component import queryAdapter
 
@@ -26,13 +25,13 @@ class TestUploadCapableAdapter(TestCase):
             adapter, uploadcapable.FileListingQuickUploadCapableFileFactory)
 
     def test_portal_type_is_alway_a_file(self):
-        adapter = queryAdapter(self.filelistingblock, IQuickUploadFileFactory)
-        # creates
-        adapter('test.jpg', None, None, None, None, None)
+        upload = queryAdapter(self.filelistingblock, IQuickUploadFileFactory)
+        upload('test.jpg',
+               'File title',
+               'File description',
+               'image/jpeg',
+               'DATA',
+               None)  # portal_type should be forced as 'File'.
         contents = self.filelistingblock.listFolderContents()
 
-        self.assertNotEqual(
-            [], contents,
-            "It was not possible to create the file. Please check the adapter")
-
-        self.assertTrue(IATFile.providedBy(contents[0]))
+        self.assertEquals(1, len(contents), 'Expect exactly one item')


### PR DESCRIPTION
@maethu Uploading images in filelistingblock will create a file instead an image

closes: https://github.com/4teamwork/bern.web/issues/183