### PR TITLE
Update dependencies for client lib.

### DIFF
--- a/ftw/simplelayout/profiles/lib/cssregistry.xml
+++ b/ftw/simplelayout/profiles/lib/cssregistry.xml
@@ -2,7 +2,7 @@
 <object name="portal_css" meta_type="Stylesheets Registry" autogroup="False">
 
     <stylesheet
-        id="++resource++ftw.simplelayout.resources/simplelayout.min.css"
+        id="++resource++ftw.simplelayout.client/dist/simplelayout.min.css"
         title=""
         cacheable="True"
         compression="safe"


### PR DESCRIPTION
Due to 4teamwork/ftw.simplelayout#159 the dependencies for the client
lib are moved.