### PR TITLE
use font-awesome type icons in toolbar.

### DIFF
--- a/ftw/simplelayout/browser/resources/theming.toolbar-icons.scss
+++ b/ftw/simplelayout/browser/resources/theming.toolbar-icons.scss
@@ -1,0 +1,15 @@
+@if $standard-iconset == font-awesome {
+
+  @each $type, $value in get-portal-type-icons-for-iconset(font-awesome) {
+    .sl-toolbox .components a.sl-toolbox-component .icon-#{$type} {
+    background: none;
+    font-style: normal;
+    display: inline;
+    position: relative;
+    top: -0.15em;
+    @extend .fa-icon;
+    @extend body.icons-on .contenttype-#{$type};
+  }
+  }
+
+}

--- a/ftw/simplelayout/resources.zcml
+++ b/ftw/simplelayout/resources.zcml
@@ -7,6 +7,9 @@
 
     <theme:resources profile="ftw.simplelayout:lib" slot="addon">
         <theme:scss file="browser/resources/integration.theme.scss" />
+
+        <theme:scss file="browser/resources/theming.toolbar-icons.scss" slot="bottom"
+                    after="ftw.theming:resources/scss/iconset_font-awesome.scss" />
     </theme:resources>
 
 </configure>


### PR DESCRIPTION
When ftw.theming is installed and the standard iconset is font-awesome, the default icons for blocks are replaced by the font-awesome icons.

Since font-awesome is only avaiable in ftw.theming's icons file we cannot its variables but need to extend existing classes and redefine the before pseudo-class.

<img width="1152" alt="bildschirmfoto 2015-07-08 um 12 05 46" src="https://cloud.githubusercontent.com/assets/7469/8567940/b7d3bb5c-2569-11e5-8ba4-f4c5b93210be.png">

/ @maethu @bierik 