### PR TITLE
Only register file factory adapter for quickupload when c.quickupload is

### DIFF
--- a/ftw/simplelayout/browser/configure.zcml
+++ b/ftw/simplelayout/browser/configure.zcml
@@ -52,6 +52,7 @@
         />
 
     <adapter
+        zcml:condition="installed collective.quickupload"
         factory=".uploadcapable.FileListingQuickUploadCapableFileFactory"
         for="ftw.simplelayout.contents.interfaces.IFileListingBlock"
         provides="collective.quickupload.interfaces.IQuickUploadFileFactory"


### PR DESCRIPTION
installed.