### PR TITLE
Do not create, or consume generated status messages for blocks.

### DIFF
--- a/ftw/simplelayout/browser/ajax/add.py
+++ b/ftw/simplelayout/browser/ajax/add.py
@@ -6,6 +6,7 @@ from plone.dexterity.browser.add import DefaultAddForm, DefaultAddView
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import BoundPageTemplate
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.statusmessages.interfaces import IStatusMessage
 from zope.component import adapts
 from zope.interface import implements
 from zope.interface import Interface
@@ -60,6 +61,10 @@ class AddView(DefaultAddView):
         if hasattr(self.form_instance, 'obj_uid'):
             obj = uuidToObject(self.form_instance.obj_uid)
             self.request.response.setHeader('Content-Type', 'application/json')
+
+            # Consume all statusmessages
+            IStatusMessage(self.request).show()
+
             return json_response(self.request,
                                  uid=self.form_instance.obj_uid,
                                  url=obj.absolute_url(),

--- a/ftw/simplelayout/browser/ajax/edit_block.py
+++ b/ftw/simplelayout/browser/ajax/edit_block.py
@@ -8,7 +8,6 @@ from plone.dexterity.i18n import MessageFactory as _
 from plone.dexterity.interfaces import IDexterityEditForm
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from Products.statusmessages.interfaces import IStatusMessage
 from z3c.form import button
 from zExceptions import BadRequest
 from zope.event import notify
@@ -42,18 +41,12 @@ class EditForm(DefaultEditForm):
             self.status = self.formErrorsMessage
             return
         self.applyChanges(data)
-        IStatusMessage(self.request).addStatusMessage(
-            _(u"Changes saved"), "info success"
-        )
         notify(EditFinishedEvent(self.context))
 
         self._finished_edit = True
 
     @button.buttonAndHandler(_(u'Cancel'), name='cancel')
     def handleCancel(self, action):
-        IStatusMessage(self.request).addStatusMessage(
-            _(u"Edit cancelled"), "info"
-        )
         notify(EditCancelledEvent(self.context))
 
     def render(self):

--- a/ftw/simplelayout/tests/test_block_statusmessage.py
+++ b/ftw/simplelayout/tests/test_block_statusmessage.py
@@ -1,0 +1,43 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+from ftw.simplelayout.testing import SimplelayoutTestCase
+from ftw.testbrowser import browsing
+from ftw.testbrowser.pages import statusmessages
+
+
+class TestBlockStatusmessage(SimplelayoutTestCase):
+
+    layer = FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.setup_sample_ftis(self.layer['portal'])
+        self.setup_block_views()
+        self.page = create(Builder('sample container'))
+
+    @browsing
+    def test_NO_statusmessage_on_block_creation(self, browser):
+        browser.login().visit(self.page, view="++add_block++SampleBlock")
+        response = browser.json
+
+        browser.open_html(response['content'])
+        browser.fill({'Title': u'This is a TextBlock',
+                      'Text': u'Some text'})
+        browser.find_button_by_label('Save').click()
+
+        browser.visit(self.page)
+        statusmessages.assert_no_messages()
+
+    @browsing
+    def test_NO_statusmessage_on_block_modification(self, browser):
+        block = create(Builder('sample block'))
+        browser.login().visit(block, view='edit')
+        response = browser.json
+
+        browser.open_html(response['content'])
+        browser.fill({'Title': u'This is a TextBlock',
+                      'Text': u'Some text'})
+        browser.find_button_by_label('Save').click()
+
+        browser.visit(self.page)
+        statusmessages.assert_no_messages()


### PR DESCRIPTION
Imho they are not necessary for simplelayout blocks, since we not reload the page...

So we got two possibilities to handle this issue.

First: Display the statusmessages

Second: Do not generate the statusmessages, or do not display the statusmessages. 


This PR imlements the second option. 
