### PR TITLE
provider: skip unavailable blocks when rendering.

### DIFF
--- a/ftw/simplelayout/browser/provider.py
+++ b/ftw/simplelayout/browser/provider.py
@@ -42,12 +42,14 @@ class BaseSimplelayoutExpression(object):
             row['class'] = 'sl-layout'
             for col in row['cols']:
                 col['class'] = 'sl-column sl-col-{}'.format(len(row['cols']))
+                col['blocks'] = filter(lambda block: block['uid'] in blocks,
+                                       col['blocks'])
+
                 for block in col['blocks']:
-                    if block['uid'] in blocks:
-                        obj = blocks[block['uid']]
-                        block['obj_html'] = self._render_block_html(obj)
-                        block['type'] = normalize_portal_type(obj.portal_type)
-                        block['url'] = obj.absolute_url()
+                    obj = blocks[block['uid']]
+                    block['obj_html'] = self._render_block_html(obj)
+                    block['type'] = normalize_portal_type(obj.portal_type)
+                    block['url'] = obj.absolute_url()
 
         # Append blocks, which are not in the simplelayout configuration into
         # the last column.

--- a/ftw/simplelayout/tests/test_simplelayout_view.py
+++ b/ftw/simplelayout/tests/test_simplelayout_view.py
@@ -153,6 +153,28 @@ class TestSimplelayoutView(SimplelayoutTestCase):
                           'Expect 2 columns')
 
     @browsing
+    def test_skips_unavailable_blocks(self, browser):
+        # The block may no longer exist or may not be visible for
+        # the current user.
+
+        block1 = create(Builder('sample block')
+                        .titled('Block 1')
+                        .within(self.container))
+
+        self.payload['default'][0]['cols'][0][
+            'blocks'][0]['uid'] = IUUID(block1)
+        self.payload['default'][1]['cols'][0][
+            'blocks'][0]['uid'] = '123xNONxEXISTINGxUIDx123'
+        self.page_config.store(self.payload)
+        transaction.commit()
+
+        browser.login().visit(self.container)
+        self.assertEquals(
+            ['http://nohost/plone/samplecontainer/block-1'],
+            map(lambda node: node.attrib.get('data-url'),
+                browser.css('.sl-block')))
+
+    @browsing
     def test_simplelayout_default_config_from_control_panel(self, browser):
         browser.login().visit(self.container, view='@@simplelayout-view')
 


### PR DESCRIPTION
When rendering a simplelayout page, blocks referenced in the config of
the page may or may not be accessible for the current user.

There may be different reasons why it is not available:

- the block is not visible to the current user by security (View)
- the block is not visible because of an expiration date
- the block is not visible because of a publication date
- the block is not visible because it was deleted
- it is a staging environment where the page has been published but not
  yet all blocks.

This fixes an error in the provider template when referenced blocks are unavailable:
```python
LocationError: ({u'uid': u'76efd9fd9f574bef8f7e661404654456'}, 'url')
```