### PR TITLE
Enable IReferenceable on all types.

### DIFF
--- a/ftw/simplelayout/profiles/default/types/ftw.simplelayout.ContentPage.xml
+++ b/ftw/simplelayout/profiles/default/types/ftw.simplelayout.ContentPage.xml
@@ -39,6 +39,7 @@
         <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
         <element value="Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes"/>
         <element value="plone.app.relationfield.behavior.IRelatedItems"/>
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/simplelayout/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
+++ b/ftw/simplelayout/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
@@ -28,6 +28,7 @@
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/simplelayout/profiles/default/types/ftw.simplelayout.GalleryBlock.xml
+++ b/ftw/simplelayout/profiles/default/types/ftw.simplelayout.GalleryBlock.xml
@@ -28,6 +28,7 @@
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/simplelayout/profiles/default/types/ftw.simplelayout.MapBlock.xml
+++ b/ftw/simplelayout/profiles/default/types/ftw.simplelayout.MapBlock.xml
@@ -28,6 +28,7 @@
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
         <element value="collective.geo.behaviour.interfaces.ICoordinates" />
         <element value="collective.geo.geographer.interfaces.IGeoreferenceable" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/simplelayout/profiles/default/types/ftw.simplelayout.TextBlock.xml
+++ b/ftw/simplelayout/profiles/default/types/ftw.simplelayout.TextBlock.xml
@@ -27,6 +27,7 @@
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
         <element value="ftw.simplelayout.behaviors.ITeaser" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/simplelayout/profiles/default/types/ftw.simplelayout.VideoBlock.xml
+++ b/ftw/simplelayout/profiles/default/types/ftw.simplelayout.VideoBlock.xml
@@ -26,6 +26,7 @@
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->


### PR DESCRIPTION
The IReferenceable behavior adds the objects to the reference catalog.
We need this in order to lookup objects by UUID.