### PR TITLE
Raises exception if block has no component definition.

### DIFF
--- a/ftw/simplelayout/browser/client/web/js/app/simplelayout/Simplelayout.js
+++ b/ftw/simplelayout/browser/client/web/js/app/simplelayout/Simplelayout.js
@@ -205,8 +205,13 @@ define(["app/simplelayout/Layoutmanager", "app/simplelayout/Toolbar", "app/toolb
     });
 
     on("blockInserted", function(block) {
-      var blockToolbar = new Toolbar(options.toolbox.options.components[block.type].actions, "horizontal", "block");
-      block.attachToolbar(blockToolbar);
+      if(options.toolbox.options.components[block.type]) {
+        var blockToolbar = new Toolbar(options.toolbox.options.components[block.type].actions, "horizontal", "block");
+        block.attachToolbar(blockToolbar);
+      }
+      else {
+        console.warn("Component for: " + block.type + " not registered");
+      }
     });
 
     return {


### PR DESCRIPTION
Fixes https://github.com/4teamwork/bern.web/issues/238
When no component is defined make a warning.