### PR TITLE
Don't render the block heading if there is no title.

### DIFF
--- a/ftw/simplelayout/browser/blocks/base.py
+++ b/ftw/simplelayout/browser/blocks/base.py
@@ -1,6 +1,6 @@
+from ftw.simplelayout.interfaces import IBlockConfiguration
 from ftw.simplelayout.interfaces import ISimplelayoutBlockView
 from Products.Five.browser import BrowserView
-from ftw.simplelayout.interfaces import IBlockConfiguration
 from zope.interface import implements
 
 
@@ -16,3 +16,18 @@ class BaseBlock(BrowserView):
 
     def __call__(self):
         return self.template()
+
+    @property
+    def block_title(self):
+        """
+        This property returns the title only if the title should be shown
+        and the title has a value.
+        """
+        title = getattr(self.context, 'title', '')
+        show_title = getattr(self.context, 'show_title', True)
+
+        if show_title and title:
+            return title
+        return ''
+
+

--- a/ftw/simplelayout/browser/blocks/configure.zcml
+++ b/ftw/simplelayout/browser/blocks/configure.zcml
@@ -15,7 +15,6 @@
         name="block_view"
         permission="zope2.View"
         class=".filelistingblock.FileListingBlockView"
-        template="templates/listingblock.pt"
         />
 
     <browser:page
@@ -37,6 +36,5 @@
         name="block_view"
         permission="zope2.View"
         class=".galleryblock.GalleryBlockView"
-        template="templates/galleryblock.pt"
         />
 </configure>

--- a/ftw/simplelayout/browser/blocks/filelistingblock.py
+++ b/ftw/simplelayout/browser/blocks/filelistingblock.py
@@ -1,14 +1,16 @@
+from ftw.simplelayout.browser.blocks.base import BaseBlock
 from ftw.simplelayout.contents.interfaces import IListingBlockColumns
 from ftw.table.interfaces import ITableGenerator
 from Products.CMFCore.utils import getToolByName
-from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
 
 
-class FileListingBlockView(BrowserView):
+class FileListingBlockView(BaseBlock):
     """ListingBlock default view"""
+
+    template = ViewPageTemplateFile('templates/listingblock.pt')
 
     def get_table_contents(self):
         catalog = getToolByName(self.context, 'portal_catalog')

--- a/ftw/simplelayout/browser/blocks/galleryblock.py
+++ b/ftw/simplelayout/browser/blocks/galleryblock.py
@@ -1,9 +1,14 @@
+from Acquisition._Acquisition import aq_inner
+from ftw.simplelayout.browser.blocks.base import BaseBlock
 from plone.app.imaging.utils import getAllowedSizes
-from Products.Five.browser import BrowserView
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
-class GalleryBlockView(BrowserView):
+class GalleryBlockView(BaseBlock):
     """GalleryBlock default view"""
+
+    template = ViewPageTemplateFile('templates/galleryblock.pt')
 
     def get_images(self):
         return self.context.listFolderContents(
@@ -11,3 +16,11 @@ class GalleryBlockView(BrowserView):
 
     def get_box_boundaries(self):
         return getAllowedSizes().get('simplelayout_galleryblock')
+
+    @property
+    def can_add(self):
+        context = aq_inner(self.context)
+        mtool = getToolByName(context, 'portal_membership')
+        permission = mtool.checkPermission(
+            'ftw.simplelayout: Add GalleryBlock', context)
+        return bool(permission)

--- a/ftw/simplelayout/browser/blocks/templates/galleryblock.pt
+++ b/ftw/simplelayout/browser/blocks/templates/galleryblock.pt
@@ -3,7 +3,10 @@
 	  tal:omit-tag="python: 1"
 	  i18n:domain="ftw.simplelayout">
 
-	<h2 tal:content="here/Title" tal:condition="here/show_title | python:True">Title</h2>
+	<h2 tal:content="view/block_title" tal:condition="view/block_title">Title</h2>
+
+  <p tal:condition="python: view.can_add and not view.get_images()"
+     i18n:translate="">This block is empty.</p>
 
 	<tal:boxes
 		repeat="img view/get_images"

--- a/ftw/simplelayout/browser/blocks/templates/listingblock.pt
+++ b/ftw/simplelayout/browser/blocks/templates/listingblock.pt
@@ -3,8 +3,8 @@
       tal:omit-tag="python: 1"
       i18n:domain="ftw.simplelayout">
 
-    <h2 tal:content="here/Title"
-        tal:condition="here/show_title | python: True" />
+    <h2 tal:content="view/block_title"
+        tal:condition="view/block_title" />
 
     <div tal:replace="structure view/render_table" />
 

--- a/ftw/simplelayout/browser/blocks/templates/textblock.pt
+++ b/ftw/simplelayout/browser/blocks/templates/textblock.pt
@@ -4,14 +4,16 @@
   tal:define="teaser_url view/teaser_url"
   i18n:domain="ftw.simplelayout">
 
-  <h2 tal:condition="here/show_title | python: True">
+  <h2 tal:condition="view/block_title">
       <a tal:attributes="href teaser_url;
-                         title here/Title"
-         tal:content="here/Title"
-         tal:omit-tag="not:teaser_url" >Title</a>
+                         title view/block_title"
+         tal:content="view/block_title"
+         tal:omit-tag="not:teaser_url">Title</a>
   </h2>
 
   <div tal:replace="structure view/get_image | nothing" />
   <div tal:replace="structure here/text/output | nothing" />
+  <p tal:condition="python: view.can_add and not (view.get_image() or here.text)"
+     i18n:translate="">This block is empty.</p>
 
 </html>

--- a/ftw/simplelayout/browser/blocks/textblock.py
+++ b/ftw/simplelayout/browser/blocks/textblock.py
@@ -1,8 +1,10 @@
+from Acquisition._Acquisition import aq_inner
 from ftw.simplelayout.behaviors import ITeaser
 from ftw.simplelayout.browser.blocks.base import BaseBlock
 from ftw.simplelayout.interfaces import ISimplelayoutActions
 from ftw.simplelayout.utils import normalize_portal_type
 from plone.memoize.instance import memoize
+from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.component import queryMultiAdapter
 
@@ -99,3 +101,11 @@ class TextBlockView(BaseBlock):
     @memoize
     def _get_default_image_float(self):
         return self._get_default_actions()['data-imagefloat']
+
+    @property
+    def can_add(self):
+        context = aq_inner(self.context)
+        mtool = getToolByName(context, 'portal_membership')
+        permission = mtool.checkPermission(
+            'ftw.simplelayout: Add TextBlock', context)
+        return bool(permission)

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-23 09:28+0000\n"
+"POT-Creation-Date: 2015-07-23 13:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -72,6 +72,11 @@ msgstr "Teaser"
 #: ./ftw/simplelayout/profiles/default/types/ftw.simplelayout.TextBlock.xml
 msgid "TextBlock"
 msgstr "Text/Bild"
+
+#: ./ftw/simplelayout/browser/blocks/templates/galleryblock.pt:8
+#: ./ftw/simplelayout/browser/blocks/templates/textblock.pt:16
+msgid "This block is empty."
+msgstr "Dieser Block hat keinen Inhalt."
 
 #: ./ftw/simplelayout/contents/videoblock.py:46
 msgid "This is no a valid youtube, or vimeo url."

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-07-23 09:28+0000\n"
+"POT-Creation-Date: 2015-07-23 13:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -74,6 +74,11 @@ msgstr ""
 
 #: ./ftw/simplelayout/profiles/default/types/ftw.simplelayout.TextBlock.xml
 msgid "TextBlock"
+msgstr ""
+
+#: ./ftw/simplelayout/browser/blocks/templates/galleryblock.pt:8
+#: ./ftw/simplelayout/browser/blocks/templates/textblock.pt:16
+msgid "This block is empty."
 msgstr ""
 
 #: ./ftw/simplelayout/contents/videoblock.py:46

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -4,6 +4,7 @@ from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
 from ftw.testbrowser import browsing
 from Products.CMFCore.utils import getToolByName
 from unittest2 import TestCase
+import transaction
 
 
 class TestGalleryBlock(TestCase):
@@ -113,3 +114,29 @@ class TestGalleryBlock(TestCase):
             len(browser.css('.sl-block-content a[rel="colorbox-{0}"]'.format(
                 gallerie_2.getId()))))
 
+    @browsing
+    def test_galleryblock_title_not_rendered_when_empty(self, browser):
+        """
+        This test makes sure that the title of the block is only rendered
+        if there is a title. Otherwise we'll end up with an empty HTML
+        tag in the template.
+        """
+        galleryblock = create(Builder('sl galleryblock')
+                              .titled('My galleryblock')
+                              .having(show_title=True)
+                              .within(self.page))
+
+        browser.login().visit(self.page)
+
+        title_css_selector = '.ftw-simplelayout-galleryblock h2'
+
+        # Make sure the title is here (in its tag).
+        self.assertEqual('My galleryblock',
+                         browser.css(title_css_selector).first.text)
+
+        # Remove the title of the block and make sure the tag is no longer
+        # there.
+        galleryblock.title = ''
+        transaction.commit()
+        browser.login().visit(self.page)
+        self.assertEqual([], browser.css(title_css_selector))


### PR DESCRIPTION
This causes some blocks to be empty which results in the edit toolbar not being shown. This is circumvented by rendering a hint about the emptiness of the block.