### PR TITLE
Addable blocks are not shown properly in Plone 5.

### DIFF
--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -15,10 +15,12 @@
       }
     };
 
+    var baseUrl = $("body").data("base-url") ? $("body").data("base-url") + "/" : $("base").attr("href");
+
     var instance = {
       settings: {
-        addableBlocksEndpoint: "./sl-ajax-addable-blocks-view",
-        saveStateEndpoint: "./sl-ajax-save-state-view",
+        addableBlocksEndpoint: baseUrl + "sl-ajax-addable-blocks-view",
+        saveStateEndpoint: baseUrl + "sl-ajax-save-state-view",
         source: ".sl-simplelayout",
         layouts: [1, 2, 4],
         canChangeLayouts: false,


### PR DESCRIPTION
In Plone 5 the base tag is no longer supported. So define the addable
blocks url and save endpoint explicitly.