### PR TITLE
update ftw.theming compatible toolbox icons.

### DIFF
--- a/ftw/simplelayout/browser/resources/theming.toolbox-icons.scss
+++ b/ftw/simplelayout/browser/resources/theming.toolbox-icons.scss
@@ -6,15 +6,26 @@
     @extend .fa-th;
   }
 
+  .sl-toolbox .components a.sl-toolbox-component [class^="icon-"],
+  .sl-toolbox .components a.sl-toolbox-component [class*=" icon-"] {
+    background: none;
+    font-style: normal;
+    display: inline;
+    position: relative;
+    top: -0.15em;
+    @extend .fa-icon;
+    @extend .fa-times-circle;
+    &:before {
+      color: fuchsia;
+    }
+  }
+
   @each $type, $value in get-portal-type-icons-for-iconset(font-awesome) {
-    .sl-toolbox .components a.sl-toolbox-component .icon-#{$type} {
-      background: none;
-      font-style: normal;
-      display: inline;
-      position: relative;
-      top: -0.15em;
-      @extend .fa-icon;
-      @extend .icons-on .contenttype-#{$type};
+    body .sl-toolbox .components a.sl-toolbox-component .icon-#{$type} {
+      @extend body.icons-on .contenttype-#{$type};
+      &:before {
+        color: inherit;
+      }
     }
   }
 


### PR DESCRIPTION
In ftw.theming the font-awesome icon selectors have changed for fixing an selector ordering conflict with the default icon.

Also the "icon-missing" color was changed to fuchsia.

This change fixes the extends selector so that icons work again and it also adds an icon-missing icon in fuchsia. We really want to have icons for all blocks ;-).

<img width="289" alt="bildschirmfoto 2015-07-24 um 12 05 51" src="https://cloud.githubusercontent.com/assets/7469/8872379/b931a654-31fc-11e5-8405-7564fc23681d.png">

/ @bierik @maethu 