### PR TITLE
Add scss factory, which hides all block types from the add menu.

### DIFF
--- a/ftw/simplelayout/browser/ajax/addable_blocks_view.py
+++ b/ftw/simplelayout/browser/ajax/addable_blocks_view.py
@@ -1,16 +1,13 @@
 from ftw.simplelayout.browser.ajax.utils import json_response
 from ftw.simplelayout.interfaces import ISimplelayoutActions
-from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from ftw.simplelayout.utils import get_block_types
 from ftw.simplelayout.utils import normalize_portal_type
 from plone.app.content.browser.folderfactories import _allowedTypes
-from plone.dexterity.interfaces import IDexterityFTI
 from Products.CMFCore.Expression import Expression
 from Products.CMFCore.Expression import getExprContext
-from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.interfaces.constrains import IConstrainTypes
 from zope.component import getMultiAdapter
 from zope.component import queryMultiAdapter
-from zope.component import queryUtility
 from zope.i18n import translate
 from zope.publisher.browser import BrowserView
 
@@ -21,7 +18,7 @@ class AddableBlocks(BrowserView):
         return json_response(self.request, dict(self.addable_blocks()))
 
     def addable_blocks(self):
-        block_types = set(self._get_block_types())
+        block_types = set(get_block_types())
         allowed_types = self._addable_types()
 
         default_actions = getMultiAdapter((self.context, self.request),
@@ -69,14 +66,4 @@ class AddableBlocks(BrowserView):
             return [fti for fti in allowed_types
                     if fti.getId() in locally_allowed]
 
-    def _get_block_types(self):
-        types_tool = getToolByName(self.context, 'portal_types')
-        typeids = types_tool.objectIds()
-        typeids.sort()
-        for type_id in typeids:
-            dx_fti = queryUtility(IDexterityFTI, name=type_id)
-            if not dx_fti:
-                continue
-            else:
-                if ISimplelayoutBlock.__identifier__ in dx_fti.behaviors:
-                    yield dx_fti
+

--- a/ftw/simplelayout/browser/ajax/addable_blocks_view.py
+++ b/ftw/simplelayout/browser/ajax/addable_blocks_view.py
@@ -18,7 +18,7 @@ class AddableBlocks(BrowserView):
         return json_response(self.request, dict(self.addable_blocks()))
 
     def addable_blocks(self):
-        block_types = set(get_block_types())
+        block_types = get_block_types()
         allowed_types = self._addable_types()
 
         default_actions = getMultiAdapter((self.context, self.request),

--- a/ftw/simplelayout/browser/dynamic_scss_resources.py
+++ b/ftw/simplelayout/browser/dynamic_scss_resources.py
@@ -1,0 +1,29 @@
+from ftw.simplelayout.utils import get_block_types
+from ftw.simplelayout.utils import normalize_portal_type
+from ftw.theming.interfaces import ISCSSResourceFactory
+from ftw.theming.resource import SCSSResource
+from zope.interface import provider
+
+
+TEMPLATE = """
+#plone-contentmenu-factories {{
+  {0} {{
+    display: none !important;
+  }}
+}}
+"""
+
+
+@provider(ISCSSResourceFactory)
+def hide_blocks_in_factory_menu(context, request):
+
+    selectors = ['']
+
+    for block_fti in get_block_types():
+        selectors.append(
+            u'.contenttype-{0}'.format(
+                normalize_portal_type(block_fti.getId())))
+
+    return SCSSResource('simplelayout_hide_blocks.scss',
+                        slot='addon',
+                        source=TEMPLATE.format(', '.join(selectors)))

--- a/ftw/simplelayout/browser/dynamic_scss_resources.py
+++ b/ftw/simplelayout/browser/dynamic_scss_resources.py
@@ -17,7 +17,7 @@ TEMPLATE = """
 @provider(ISCSSResourceFactory)
 def hide_blocks_in_factory_menu(context, request):
 
-    selectors = ['']
+    selectors = []
 
     for block_fti in get_block_types():
         selectors.append(

--- a/ftw/simplelayout/browser/resources/integration.default.css
+++ b/ftw/simplelayout/browser/resources/integration.default.css
@@ -46,3 +46,12 @@
   display: table-cell;
   vertical-align: middle;
 }
+
+/* Hide block types form add menu */
+#plone-contentmenu-factories .contenttype-ftw-simplelayout-filelistingblock,
+#plone-contentmenu-factories .contenttype-ftw-simplelayout-galleryblock,
+#plone-contentmenu-factories .contenttype-ftw-simplelayout-mapblock,
+#plone-contentmenu-factories .contenttype-ftw-simplelayout-textblock,
+#plone-contentmenu-factories .contenttype-ftw-simplelayout-videoblock {
+  display: none !important;
+}

--- a/ftw/simplelayout/resources.zcml
+++ b/ftw/simplelayout/resources.zcml
@@ -5,6 +5,8 @@
 
     <include package="ftw.theming" file="meta.zcml" />
 
+    <theme:scss_factory factory=".browser.dynamic_scss_resources.hide_blocks_in_factory_menu" />
+
     <theme:resources profile="ftw.simplelayout:lib" slot="addon">
         <theme:scss file="browser/resources/integration.theme.scss" />
 

--- a/ftw/simplelayout/utils.py
+++ b/ftw/simplelayout/utils.py
@@ -1,11 +1,11 @@
 from ftw.simplelayout.interfaces import IBlockProperties
 from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from operator import methodcaller
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
-from zope.component import queryUtility
 from zope.component.hooks import getSite
 
 
@@ -24,12 +24,9 @@ def get_block_html(block):
 def get_block_types():
     platform = getSite()
     types_tool = getToolByName(platform, 'portal_types')
-    typeids = types_tool.objectIds()
-    typeids.sort()
-    for type_id in typeids:
-        dx_fti = queryUtility(IDexterityFTI, name=type_id)
-        if not dx_fti:
-            continue
-        else:
-            if ISimplelayoutBlock.__identifier__ in dx_fti.behaviors:
-                yield dx_fti
+
+    dexterity_ftis = filter(
+        IDexterityFTI.providedBy, types_tool.objectValues())
+
+    return filter(
+        lambda fti: ISimplelayoutBlock.__identifier__ in fti.behaviors, dexterity_ftis)

--- a/ftw/simplelayout/utils.py
+++ b/ftw/simplelayout/utils.py
@@ -1,7 +1,12 @@
 from ftw.simplelayout.interfaces import IBlockProperties
+from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from plone.dexterity.interfaces import IDexterityFTI
 from plone.i18n.normalizer.interfaces import IIDNormalizer
+from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.component import queryMultiAdapter
+from zope.component import queryUtility
+from zope.component.hooks import getSite
 
 
 def normalize_portal_type(portal_type):
@@ -14,3 +19,17 @@ def get_block_html(block):
                                    IBlockProperties)
     viewname = properties.get_current_view_name()
     return block.restrictedTraverse(viewname)()
+
+
+def get_block_types():
+    platform = getSite()
+    types_tool = getToolByName(platform, 'portal_types')
+    typeids = types_tool.objectIds()
+    typeids.sort()
+    for type_id in typeids:
+        dx_fti = queryUtility(IDexterityFTI, name=type_id)
+        if not dx_fti:
+            continue
+        else:
+            if ISimplelayoutBlock.__identifier__ in dx_fti.behaviors:
+                yield dx_fti


### PR DESCRIPTION
Hide block types from add menu with ftw.theming and without ftw.theming. 

:exclamation: the `!important` is necessary, since the `authoring.css` from plone also has a !important.