### PR TITLE
Remove behaviors, which are not necessary

### DIFF
--- a/ftw/simplelayout/profiles/default/types/ftw.simplelayout.ContentPage.xml
+++ b/ftw/simplelayout/profiles/default/types/ftw.simplelayout.ContentPage.xml
@@ -33,11 +33,8 @@
     <property name="behaviors">
         <element value="ftw.simplelayout.interfaces.ISimplelayout" />
         <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
-        <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
         <element value="plone.app.content.interfaces.INameFromTitle" />
-        <element value="plone.app.dexterity.behaviors.exclfromnav.IExcludeFromNavigation"/>
-        <element value="Products.CMFPlone.interfaces.constrains.ISelectableConstrainTypes"/>
-        <element value="plone.app.relationfield.behavior.IRelatedItems"/>
+        <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
         <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 


### PR DESCRIPTION
As discussed with @jone ftw.simplelayout should only provide basic behaviors.
This means the decision, which dexterity metadata behaviors should be active on a contentpage should delegated to the integration.