### PR TITLE
Block draggable indicator is added when dragging a layout.

### DIFF
--- a/ftw/simplelayout/browser/client/web/js/app/simplelayout/Simplelayout.js
+++ b/ftw/simplelayout/browser/client/web/js/app/simplelayout/Simplelayout.js
@@ -72,7 +72,9 @@ define(["app/simplelayout/Layoutmanager", "app/simplelayout/Toolbar", "app/toolb
       cursor: "pointer",
       start: function() {
         enableFrames();
-        $(document.documentElement).addClass("sl-block-dragging");
+        if($(this).hasClass("sl-toolbox-component")) {
+          $(document.documentElement).addClass("sl-block-dragging");
+        }
       },
       stop: function() {
         disableFrames();


### PR DESCRIPTION
Only add class "sl-block-dragging" when a component is dragging.