### PR TITLE
use ftw.autofeature; minor fixes

### DIFF
--- a/ftw/simplelayout/behaviors.zcml
+++ b/ftw/simplelayout/behaviors.zcml
@@ -7,8 +7,8 @@
     <include package="plone.behavior" file="meta.zcml" />
 
     <plone:behavior
-        title="Simplelayout indexing behavior"
-        description="Enabled block indexing on a container"
+        title="Simplelayout page"
+        description="Simplelayout page marker behavior"
         provides="ftw.simplelayout.interfaces.ISimplelayout"
         />
 

--- a/ftw/simplelayout/behaviors.zcml
+++ b/ftw/simplelayout/behaviors.zcml
@@ -18,13 +18,11 @@
         provides="ftw.simplelayout.interfaces.ISimplelayoutBlock"
         />
 
-    <configure zcml:condition="installed collective.dexteritytextindexer">
-        <adapter
-            factory=".indexer.BlockSearchableTextIndexer"
-            provides="collective.dexteritytextindexer.IDynamicTextIndexExtender"
-            name="ISimplelayout"
-            />
-    </configure>
+    <adapter
+        factory=".indexer.BlockSearchableTextIndexer"
+        provides="collective.dexteritytextindexer.IDynamicTextIndexExtender"
+        name="ISimplelayout"
+        />
 
     <configure zcml:condition="installed plone.formwidget.contenttree">
         <plone:behavior

--- a/ftw/simplelayout/behaviors.zcml
+++ b/ftw/simplelayout/behaviors.zcml
@@ -2,7 +2,7 @@
     xmlns="http://namespaces.zope.org/zope"
     xmlns:plone="http://namespaces.plone.org/plone"
     xmlns:zcml="http://namespaces.zope.org/zcml"
-    i18n_domain="simplelayout">
+    i18n_domain="ftw.simplelayout">
 
     <include package="plone.behavior" file="meta.zcml" />
 

--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -1,10 +1,14 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:autofeature="http://namespaces.zope.org/autofeature"
     xmlns:five="http://namespaces.zope.org/five"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.simplelayout">
+
+    <include package="ftw.autofeature" file="meta.zcml" />
+    <autofeature:extras />
 
     <five:registerPackage package="." initialize=".initialize" />
 

--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -15,7 +15,7 @@
     <include file="permissions.zcml" />
     <include package=".browser" />
     <include package=".portlets" />
-    <include file="behaviors.zcml" zcml:condition="not-have plone-5"/>
+    <include file="behaviors.zcml" />
     <include file="lawgiver.zcml" zcml:condition="installed ftw.lawgiver" />
     <include file="resources.zcml" zcml:condition="installed ftw.theming" />
 

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(name='ftw.simplelayout',
           'collective.js.jqueryui',
           # 'cssutils', # TODO: is this used anywhere?
           'Persistence',
+          'ftw.autofeature',
           'plone.api',
           'plone.app.blob',
           'plone.uuid',


### PR DESCRIPTION
- use ftw.autofeature
- remove ``installed collective.dexteritytextindexer`` condition for ``BlockSearchableTextIndexer``
- fix description of ``ISimpleleayout`` behavior
- also provide behaviors for Plone 5 :exclamation: 

@maethu 
/cc @buchi 