### PR TITLE
Mapblock searchresults not working.

### DIFF
--- a/ftw/simplelayout/browser/resources/Overlay.js
+++ b/ftw/simplelayout/browser/resources/Overlay.js
@@ -46,6 +46,9 @@
       onCancelCallback: function(){},
       onSubmitCallback: function(){},
       open: function() {
+        if(this.settings.speed === 0) {
+          this.element.show();
+        }
         this.overlay.load();
         this.bindCloseEvents();
         root.addClass("overlay-open");
@@ -53,6 +56,9 @@
       close: function() {
         if(this.canClose()) {
           this.onCancelCallback();
+          if(this.settings.speed === 0) {
+            this.element.hide();
+          }
           this.overlay.close();
           root.removeClass("overlay-open");
           $(this.element).trigger("overlayCancel", this);


### PR DESCRIPTION
Fixes #229 

Mapblock has triggered an overlay submit event instead of asynchronously
loading the location suggestions. The overlay's load method does not
instantly show the overlay. So if the speed is set to 0 make the overlay
visible manually before loading the overlay.