### PR TITLE
Expose the available block types on the simplelayout view.

### DIFF
--- a/ftw/simplelayout/browser/configure.zcml
+++ b/ftw/simplelayout/browser/configure.zcml
@@ -27,6 +27,7 @@
         name="simplelayout-view"
         permission="zope2.View"
         class=".simplelayout.SimplelayoutView"
+        allowed_attributes="addable_block_types"
         />
 
     <browser:page

--- a/ftw/simplelayout/browser/simplelayout.py
+++ b/ftw/simplelayout/browser/simplelayout.py
@@ -1,3 +1,4 @@
+from ftw.simplelayout import utils
 from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.simplelayout.interfaces import ISimplelayoutView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -32,3 +33,11 @@ class SimplelayoutView(BrowserView):
 
     def update_simplelayout_settings(self, settings):
         pass
+
+    def addable_block_types(self):
+        """
+        Returns a list of dotted fti ids.
+
+        Example: ['ftw.simplelayout.TextBlock']
+        """
+        return [block_type.id for block_type in utils.get_block_types()]

--- a/ftw/simplelayout/tests/test_simplelayout_view.py
+++ b/ftw/simplelayout/tests/test_simplelayout_view.py
@@ -366,3 +366,15 @@ class TestSimplelayoutView(SimplelayoutTestCase):
             'block-1',
             browser.css('.sl-layout a').first.attrib['name']
         )
+
+    @browsing
+    def test_addable_block_types_view_property(self, browser):
+        create(Builder('sample block')
+               .titled('Block 1')
+               .within(self.container))
+
+        view = self.container.restrictedTraverse('@@simplelayout-view')
+        self.assertEqual(
+            ['SampleBlock'],
+            view.addable_block_types()
+        )


### PR DESCRIPTION
This is useful to query the available block types in restricted python scripts.