### PR TITLE
Improve gallery listing - crop images.

### DIFF
--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -7,13 +7,6 @@
 @include portal-type-font-awesome-icon(ftw-simplelayout-textblock, paragraph);
 @include portal-type-font-awesome-icon(ftw-simplelayout-videoblock, film);
 
-@mixin vertical-align($position: relative) {
-  position: $position;
-  top: 50%;
-  -webkit-transform: translateY(-50%);
-  -ms-transform: translateY(-50%);
-  transform: translateY(-50%);
-}
 
 @mixin horizontal-align() {
   display: block;
@@ -74,7 +67,6 @@
     position: relative;
 }
 .galleryblockImageWrapper img{
-  @include vertical-align();
   @include horizontal-align();
 }
 .contenttreeWindowBlocker {

--- a/ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt
@@ -8,10 +8,7 @@
   <p tal:condition="python: view.can_add and not view.get_images()"
      i18n:translate="">This block is empty.</p>
 
-	<tal:boxes
-		repeat="img view/get_images"
-		define="width python:str(view.get_box_boundaries()[0])+'px';
-				height python:str(view.get_box_boundaries()[1])+'px'">
+	<tal:boxes repeat="img view/get_images">
 
 		<div class="galleryblockImageWrapper">
 			<a class="colorboxLink" href="#"
@@ -19,8 +16,10 @@
 					title string:${img/title_or_id} ${img/Description};
 					rel string:colorbox-${here/getId};
 					href img/absolute_url">
-				<img tal:replace="structure img/@@images/image/simplelayout_galleryblock" />
+                <img tal:define="scales img/@@images"
+                     tal:replace="structure python: scales.tag('image', scale='simplelayout_galleryblock', direction='down')" />
 			</a>
 		</div>
+
 	</tal:boxes>
 </html>


### PR DESCRIPTION
Crop images to 130 x 130 Pixel by default. 
![screen shot 2015-09-07 at 09 27 13](https://cloud.githubusercontent.com/assets/437933/9711284/ba4f842a-5542-11e5-8627-e3fce894b16c.png)

This way we can make sure every images uses the same amount of space. 
