### PR TITLE
Fix UnicodeDecodeError on galleryblock listing.

### DIFF
--- a/ftw/simplelayout/contenttypes/browser/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/browser/galleryblock.py
@@ -28,7 +28,8 @@ class GalleryBlockView(BaseBlock):
         return bool(permission)
 
     def generate_image_title(self, img):
+        title = img.title_or_id().decode('utf-8')
         return translate(_(u'galleryblock_link_title',
                            default=u'${title}, opens in a overlay.',
-                           mapping={'title': img.title_or_id()}),
+                           mapping={'title': title}),
                          context=self.request)

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -60,7 +60,7 @@ class TestGalleryBlock(TestCase):
                .within(block))
 
         create(Builder('image')
-               .titled('Test image')
+               .titled('Test im\xc3\xa4ge')
                .with_dummy_content()
                .within(block))
 


### PR DESCRIPTION
Image title may contain umlauts.