### PR TITLE
Page get downloaded several times on reload through XHR.

### DIFF
--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -53,9 +53,7 @@
           var toolbox = new global.Toolbox({ layouts: self.settings.layouts, components: components, canChangeLayouts: self.settings.canChangeLayouts });
           self.simplelayout = new global.Simplelayout({source: self.settings.source, toolbox: toolbox});
           self.simplelayout.on("blockInserted", function(block) {
-            currentBlock = block;
             var blockData = block.element.data();
-            addOverlay.load(addFormUrl);
             var layout = self.simplelayout.getManagers()[blockData.container].layouts[blockData.layoutId];
             if(layout.hasBlocks()) {
               layout.toolbar.disable("delete");
@@ -63,6 +61,12 @@
           });
           toolbox.attachTo($("body"));
           self.simplelayout.deserialize($("body"));
+
+          self.simplelayout.on("blockInserted", function(block) {
+            currentBlock = block;
+            addOverlay.load(addFormUrl);
+          });
+
           callback(self.simplelayout);
         });
 


### PR DESCRIPTION
The ```blockInserted``` event was binded before the simplelayout DOM
structure got serialized. So every time when a block was
inserted a new Overlay was loaded. Because the URL for getting the form
was empty the whole page got downloaded.

Sorry for that :disappointed: 