### PR TITLE
Disable ajax spinner for toolbox.

### DIFF
--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -25,7 +25,7 @@
 
     var instance = {
       settings: {
-        toolboxDataEndpoint: baseUrl + "sl-toolbox-view",
+        toolboxDataEndpoint: baseUrl + "sl-toolbox-view" + "?spinner=false",
         saveStateEndpoint: baseUrl + "sl-ajax-save-state-view",
         source: ".sl-simplelayout",
         layouts: [1, 2, 4],


### PR DESCRIPTION
Depends on https://github.com/OneGov/plonetheme.onegovbear/pull/69