### PR TITLE
Revert "Disable ajax spinner for toolbox."

### DIFF
--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -25,7 +25,7 @@
 
     var instance = {
       settings: {
-        toolboxDataEndpoint: baseUrl + "sl-toolbox-view" + "?spinner=false",
+        toolboxDataEndpoint: baseUrl + "sl-toolbox-view",
         saveStateEndpoint: baseUrl + "sl-ajax-save-state-view",
         source: ".sl-simplelayout",
         layouts: [1, 2, 4],


### PR DESCRIPTION
Reverts 4teamwork/ftw.simplelayout#265

The theme, or plone should decide how the spinner is working. 