### PR TITLE
Change the "store" page configuration behavior

### DIFF
--- a/ftw/simplelayout/configuration.py
+++ b/ftw/simplelayout/configuration.py
@@ -44,12 +44,17 @@ def make_resursive_persistent(conf):
     return persist(conf)
 
 
-def columns_in_config(config):
+def columns_in_config(config, container=None):
     """Returns each column-dict found in the config.
     """
     columns = []
 
-    for container in config.values():
+    if container is None:
+        containers = config.values()
+    else:
+        containers = [config.get(container, [{"cols": [{"blocks": []}]}])]
+
+    for container in containers:
         for layout in container:
             columns.extend(layout.get('cols', ()))
 
@@ -107,10 +112,12 @@ def synchronize_page_config_with_blocks(page):
 
         column['blocks'][:] = new_blocks
 
-    # Add missing blocks to the bottom of the first column found.
+    # Add missing blocks to the bottom of the first column of the "default"
+    # container.
     added = block_uids_missing_in_config(page)
     for uid in added:
-        columns[0]['blocks'].append({'uid': uid})
+        default_columns = columns_in_config(config, container='default')
+        default_columns[0]['blocks'].append({'uid': uid})
 
     IPageConfiguration(page).store(config)
     return {'added': added, 'removed': removed}

--- a/ftw/simplelayout/configuration.py
+++ b/ftw/simplelayout/configuration.py
@@ -134,7 +134,12 @@ class PageConfiguration(object):
     def store(self, conf):
         self.check_permission(conf)
         annotations = IAnnotations(self.context)
-        annotations[SL_ANNOTATION_KEY] = make_resursive_persistent(conf)
+
+        storage = annotations.get(SL_ANNOTATION_KEY, None)
+        if storage:
+            storage.update(make_resursive_persistent(conf))
+        else:
+            annotations[SL_ANNOTATION_KEY] = make_resursive_persistent(conf)
 
     def load(self):
         annotations = IAnnotations(self.context)

--- a/ftw/simplelayout/tests/test_configuration.py
+++ b/ftw/simplelayout/tests/test_configuration.py
@@ -192,6 +192,29 @@ class TestPageConfigFunctions(SimplelayoutTestCase):
                 {'uid': 'staticuid00000000000000000000002'}]}]}]},
             IPageConfiguration(page).load())
 
+    def test_store_partial_updates(self):
+        page = create(Builder('sample container'))
+        config = IPageConfiguration(page)
+
+        state = {'default': [{'cols': [{'blocks': [{'uid': 'foo'}]}]},
+                             {'cols': [{'blocks': [{'uid': 'bar'}]},
+                                       {'blocks': []}]}],
+                 'sidebar': [{'cols': [{'blocks': [{'uid': 'baz'},
+                                                   {'uid': 'foobar'}]}]}]}
+        config.store(state)
+
+        partial_state = {'sidebar': [{'cols': [
+            {'blocks': [{'uid': 'baz'}]}]}]}
+        config.store(partial_state)
+
+        # Remove block "foobar" from "sidebar" slot
+        new_state = {'default': [{'cols': [{'blocks': [{'uid': 'foo'}]}]},
+                                 {'cols': [{'blocks': [{'uid': 'bar'}]},
+                                           {'blocks': []}]}],
+                     'sidebar': [{'cols': [{'blocks': [{'uid': 'baz'}]}]}]}
+
+        self.assertEquals(new_state, config.load())
+
 
 class TestBlockConfiguration(SimplelayoutTestCase):
     layer = FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING


### PR DESCRIPTION
This makes it possible to have multiple simplelayout views with different slots on one object. 

Example:
1. Default simplelayout view (only one slot -> `default`
2. Special search view with one slot -> `search`

The old behavior always reassigned the new store, which means if someone edited the simplelayout page with the `search` slot, the informations of the `default` slot was doomed.

The new implementation does now an `update` instead. This way only the sots used in the DOM are updated. 


For this new usecase I also hat to change the behavior what happen if a block was not present in store. 
**Before:** Get all columns and append the block to the first column. 

**New:** Get the first column of the `default` slot.

 