### PR TITLE
The default page configuration should be persistent, since it will be updated later.

### DIFF
--- a/ftw/simplelayout/configuration.py
+++ b/ftw/simplelayout/configuration.py
@@ -143,8 +143,9 @@ class PageConfiguration(object):
 
     def load(self):
         annotations = IAnnotations(self.context)
-        return deepcopy(annotations.setdefault(SL_ANNOTATION_KEY,
-                                               self._default_page_config()))
+        return deepcopy(annotations.setdefault(
+            SL_ANNOTATION_KEY,
+            make_resursive_persistent(self._default_page_config())))
 
     def check_permission(self, new_state):
         def flatten(payload):

--- a/ftw/simplelayout/tests/test_configuration.py
+++ b/ftw/simplelayout/tests/test_configuration.py
@@ -48,6 +48,10 @@ class TestPageConfiguration(SimplelayoutTestCase):
         )
         self.assert_recursive_persistence(config.load())
 
+    def test_default_config_is_recursive_persistent(self):
+        config = IPageConfiguration(create(Builder('sample container')))
+        self.assert_recursive_persistence(config.load())
+
     def test_loaded_config_mutations_are_not_stored(self):
         config = IPageConfiguration(create(Builder('sample container')))
         config.store(


### PR DESCRIPTION

With #268 we introduced updating the storage, instead of new reassign the whole storage.

@jone sry I missed this one. 