### PR TITLE
Filter block states with no `uid` key.

### DIFF
--- a/ftw/simplelayout/browser/provider.py
+++ b/ftw/simplelayout/browser/provider.py
@@ -53,8 +53,9 @@ class BaseSimplelayoutExpression(object):
             row['class'] = 'sl-layout'
             for col in row['cols']:
                 col['class'] = 'sl-column sl-col-{}'.format(len(row['cols']))
-                col['blocks'] = filter(lambda block: block['uid'] in blocks,
-                                       col['blocks'])
+                col['blocks'] = filter(
+                    lambda block: block.get('uid', '') in blocks,
+                    col['blocks'])
 
                 for block in col['blocks']:
                     obj = blocks[block['uid']]
@@ -122,7 +123,8 @@ class BaseSimplelayoutExpression(object):
             for row in container:
                 for col in row['cols']:
                     for block in col['blocks']:
-                        saved_blocks.append(block['uid'])
+                        if 'uid' in block:
+                            saved_blocks.append(block['uid'])
 
         return filter(lambda x: x[0] not in saved_blocks,
                       self._blocks().items())

--- a/ftw/simplelayout/tests/test_simplelayout_view.py
+++ b/ftw/simplelayout/tests/test_simplelayout_view.py
@@ -170,6 +170,17 @@ class TestSimplelayoutView(SimplelayoutTestCase):
                 browser.css('.sl-block')))
 
     @browsing
+    def test_empty_block_state_does_not_break_the_view(self, browser):
+        self.payload['default'][0]['cols'][0]['blocks'].append({})
+        self.page_config.store(self.payload)
+        transaction.commit()
+
+        browser.login().visit(self.container)
+        self.assertTrue(
+            browser.css('body.template-simplelayout-view'),
+            'Expect to be on the simplelayout template, not the error page.')
+
+    @browsing
     def test_simplelayout_default_config_from_control_panel(self, browser):
         browser.login().visit(self.container, view='@@simplelayout-view')
 


### PR DESCRIPTION
This fixes an issue if the block state was somehow stored in a broken manner.