### PR TITLE
Also check for an existing target on internal refs (teaser).

### DIFF
--- a/ftw/simplelayout/contenttypes/browser/textblock.py
+++ b/ftw/simplelayout/contenttypes/browser/textblock.py
@@ -20,7 +20,7 @@ class TextBlockView(BaseBlock):
         if not teaser:
             return None
 
-        if teaser.internal_link:
+        if teaser.internal_link and teaser.internal_link.to_object:
             return teaser.internal_link.to_object.absolute_url()
         elif teaser.external_link:
             return teaser.external_link

--- a/ftw/simplelayout/tests/test_teaser_behavior.py
+++ b/ftw/simplelayout/tests/test_teaser_behavior.py
@@ -2,11 +2,13 @@ from ftw.builder import Builder
 from ftw.builder import create
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
 from ftw.simplelayout.testing import IS_PLONE_5
+from ftw.testbrowser import browsing
 from unittest2 import skipUnless
 from unittest2 import TestCase
 from z3c.relationfield import RelationValue
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
+import transaction
 
 
 if not IS_PLONE_5:
@@ -33,3 +35,19 @@ class TestTeaserBehavior(TestCase):
                           ITeaser(textblock).external_link)
         self.assertEquals(self.page,
                           ITeaser(textblock).internal_link.to_object)
+
+    @browsing
+    def test_broken_internal_link(self, browser):
+        target = create(Builder('sl content page'))
+        textblock = create(Builder('sl textblock')
+                           .within(self.page)
+                           .having(internal_link=RelationValue(
+                                   self.intids.getId(target))))
+
+        self.layer['portal'].manage_delObjects(ids=[target.getId()])
+        transaction.commit()
+
+        browser.login().visit(textblock, view='block_view')
+        self.assertFalse(
+            browser.css('a'),
+            'Expect no link, since the internal target does not exist.')


### PR DESCRIPTION
This fixes an `AttributeError` if the internal target no longer exists. 