### PR TITLE
Fix unwrap_persistance handler method

### DIFF
--- a/ftw/simplelayout/handlers.py
+++ b/ftw/simplelayout/handlers.py
@@ -14,11 +14,11 @@ def unwrap_persistence(conf):
     """Unwrap recursice persistent page state
     """
     def unwrap(data):
-        if isinstance(data, PersistentMapping):
+        if isinstance(data, (PersistentMapping, dict)):
             data = dict(data)
             for key, value in data.items():
                 data[key] = unwrap(value)
-        elif isinstance(data, PersistentList):
+        elif isinstance(data, (PersistentList, list, tuple, set)):
             return list(map(unwrap, data))
         else:
             # Usually we got basestrings, or integer here, so do nothing.

--- a/ftw/simplelayout/testing.py
+++ b/ftw/simplelayout/testing.py
@@ -94,6 +94,22 @@ class SimplelayoutTestCase(TestCase):
 
         is_persistent(structure)
 
+    def assert_unwrapped_persistence(self, structure):
+        def is_unwrapped(item):
+            if not isinstance(item, basestring) and not isinstance(item, int):
+                assert isinstance(item, dict) or \
+                    isinstance(item, list), \
+                    '{0} needs to be unwrapped'.format(str(item))
+
+                if hasattr(item, 'values'):
+                    item = item.values()
+                for subitem in item:
+                    is_unwrapped(subitem)
+            else:
+                return
+
+        is_unwrapped(structure)
+
     def setup_sample_ftis(self, portal):
         sample_types.setup_ftis(portal)
 

--- a/ftw/simplelayout/tests/test_handlers.py
+++ b/ftw/simplelayout/tests/test_handlers.py
@@ -1,0 +1,59 @@
+from ftw.simplelayout.handlers import unwrap_persistence
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+from ftw.simplelayout.testing import SimplelayoutTestCase
+from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
+
+
+class TestUnwrapPersistance(SimplelayoutTestCase):
+
+    layer = FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+
+    def test_unwrap_persistance(self):
+        config = PersistentMapping(
+            {'default': PersistentList([
+                PersistentMapping({'cols': "columns"}),
+                PersistentMapping({'cols': 'columns'})]
+                )})
+
+        unwrapped_config = unwrap_persistence(config)
+
+        self.assert_unwrapped_persistence(unwrapped_config)
+
+    def test_unwrap_partial_persistance_with_list(self):
+        config = PersistentMapping(
+            {'default': list([
+                PersistentMapping({'cols': "columns"}),
+                PersistentMapping({'cols': 'columns'})])})
+
+        unwrapped_config = unwrap_persistence(config)
+
+        self.assert_unwrapped_persistence(unwrapped_config)
+
+    def test_unwrap_partial_persistance_with_dict(self):
+        config = dict(
+            {'default': PersistentList([
+                PersistentMapping({'cols': "columns"}),
+                PersistentMapping({'cols': 'columns'})])})
+
+        unwrapped_config = unwrap_persistence(config)
+
+        self.assert_unwrapped_persistence(unwrapped_config)
+
+    def test_unwrap_partial_persistance_with_tuple(self):
+        config = PersistentMapping(
+            {'default': tuple([
+                PersistentMapping({'cols': "columns"}),
+                PersistentMapping({'cols': 'columns'})])})
+
+        unwrapped_config = unwrap_persistence(config)
+
+        self.assert_unwrapped_persistence(unwrapped_config)
+
+    def test_unwrap_partial_persistance_with_set(self):
+        config = PersistentMapping(
+            {'default': set(['value1', 'value2'])})
+
+        unwrapped_config = unwrap_persistence(config)
+
+        self.assert_unwrapped_persistence(unwrapped_config)


### PR DESCRIPTION
Fix an issue if the page_config is only partial persistent after retrieving a versioned contentpage (I don't know why it is partial persistent, but it is). Serializing a persistent dict or map is not possible and we get a json encode error.

If the ``unwrap_persistance`` method gets a partial persistent config, it will stop unwrap.

This PR will fix this. The unwrapper will unwrapp all possible elements, doesn't matter if it is already unwrapped or not.