### PR TITLE
Default layout restrictions only works for bern.web project.

### DIFF
--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -101,10 +101,6 @@
 
       simplelayout.restore(target);
 
-      var sidebarContainer = $("#portletright").data().id;
-
-      simplelayout.options.layoutRestrictions = { 2: [sidebarContainer], 3: [sidebarContainer], 4: [sidebarContainer] };
-
       simplelayout.on("block-committed", function(block) {
         block.element.css("opacity", "0");
         block.element.animate(


### PR DESCRIPTION
If the sidebar container is not rendered the javascript throws an error
and stops further execution of the script. So the layout restrictions
should be defined serverside dynamically for the diffrent views.