### PR TITLE
Add Simplelayout view as possible front page layout + addable types on the plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add Simlelayout view as possible front page layout + addable types on the plone site.
+  This change provides no upgrade step, since it may break the configuration.
+  [mathias.leimgruber]
 
 
 1.0a1 (2015-12-04)

--- a/ftw/simplelayout/contenttypes/configure.zcml
+++ b/ftw/simplelayout/contenttypes/configure.zcml
@@ -5,6 +5,7 @@
     xmlns:plone="http://namespaces.plone.org/plone"
     xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
     xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="ftw.simplelayout">
 
     <include package="plone.behavior" file="meta.zcml" />
@@ -34,5 +35,14 @@
         profile="ftw.simplelayout.contenttypes:default"
         directory="./upgrades"
         />
+
+
+  <include package="plone.app.contentmenu" />
+
+  <browser:menuItem
+      for="ftw.simplelayout.interfaces.ISimplelayout"
+      menu="plone_displayviews"
+      title="Simplelayout View"
+      action="@@simplelayout-view" />
 
 </configure>

--- a/ftw/simplelayout/contenttypes/profiles/default/types/Plone_Site.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<object name="Plone Site"
+   meta_type="Factory-based Type Information with dynamic views"
+   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+ <property name="view_methods" purge="False">
+  <element value="simplelayout-view"/>
+ </property>
+
+ <property name="allowed_content_types" purge="False">
+  <element value="ftw.simplelayout.ContentPage"/>
+  <element value="ftw.simplelayout.TextBlock" />
+  <element value="ftw.simplelayout.FileListingBlock" />
+  <element value="ftw.simplelayout.VideoBlock" />
+  <element value="ftw.simplelayout.GalleryBlock" />
+ </property>
+
+
+</object>

--- a/ftw/simplelayout/contenttypes/upgrades/20160113155920_configure_addable_types/types/Plone_Site.xml
+++ b/ftw/simplelayout/contenttypes/upgrades/20160113155920_configure_addable_types/types/Plone_Site.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<object name="Plone Site"
+   meta_type="Factory-based Type Information with dynamic views"
+   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+ <property name="view_methods" purge="False">
+  <element value="simplelayout-view"/>
+ </property>
+
+ <property name="allowed_content_types" purge="False">
+  <element value="ftw.simplelayout.ContentPage"/>
+  <element value="ftw.simplelayout.TextBlock" />
+  <element value="ftw.simplelayout.FileListingBlock" />
+  <element value="ftw.simplelayout.VideoBlock" />
+  <element value="ftw.simplelayout.GalleryBlock" />
+ </property>
+
+
+</object>

--- a/ftw/simplelayout/contenttypes/upgrades/20160113155920_configure_addable_types/upgrade.py
+++ b/ftw/simplelayout/contenttypes/upgrades/20160113155920_configure_addable_types/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ConfigureAddableTypes(UpgradeStep):
+    """Configure addable types.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-04 14:19+0000\n"
+"POT-Creation-Date: 2016-01-13 13:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,10 +23,6 @@ msgstr "Inhaltsseite"
 msgid "Delete"
 msgstr "Löschen"
 
-#: ./ftw/simplelayout/contenttypes/configure.zcml:23
-msgid "Extends a content by two fields internal and external link"
-msgstr ""
-
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
 msgid "FileListingBlock"
 msgstr "Dateiauflistung"
@@ -44,10 +40,6 @@ msgstr "ID"
 msgid "It's not possible to have an internal_link and an external_link together"
 msgstr "Es ist nicht möglich, einen internen und externen Link gleichzeitig zu definieren."
 
-#: ./ftw/simplelayout/configure.zcml:63
-msgid "Javascript resources from client are not compressed"
-msgstr ""
-
 #: ./ftw/simplelayout/mapblock/profiles/default/types/ftw.simplelayout.MapBlock.xml
 msgid "MapBlock"
 msgstr "Karte"
@@ -56,25 +48,8 @@ msgstr "Karte"
 msgid "Save"
 msgstr "Speichern"
 
-#: ./ftw/simplelayout/contenttypes/configure.zcml:31
-msgid "Simlelayout default content types"
-msgstr ""
-
-#: ./ftw/simplelayout/configure.zcml:44
-msgid "Simlelayout js library"
-msgstr ""
-
-#: ./ftw/simplelayout/mapblock/configure.zcml:21
-msgid "Simlelayout map block type"
-msgstr ""
-
-#: ./ftw/simplelayout/behaviors.zcml:18
-msgid "Simplelayout block behavior"
-msgstr ""
-
-#: ./ftw/simplelayout/behaviors.zcml:18
-msgid "Simplelayout block content marker"
-msgstr ""
+msgid "Simplelayout View"
+msgstr "Simplelayout Ansicht"
 
 #: ./ftw/simplelayout/interfaces.py:82
 msgid "Simplelayout default configuration"
@@ -85,21 +60,9 @@ msgstr "Simplelayout Standard-Konfiguration"
 msgid "Simplelayout default settings"
 msgstr "Simplelayout Standard-Einstellungen"
 
-#: ./ftw/simplelayout/behaviors.zcml:12
-msgid "Simplelayout page"
-msgstr ""
-
-#: ./ftw/simplelayout/behaviors.zcml:12
-msgid "Simplelayout page marker behavior"
-msgstr ""
-
 #: ./ftw/simplelayout/browser/controlpanel/simplelayout_controlpanel.py:16
 msgid "Simplelayout settings"
 msgstr "Simplelayout Einstellungen"
-
-#: ./ftw/simplelayout/contenttypes/configure.zcml:23
-msgid "Simplelayout teaser behavior"
-msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/behaviors.py:17
 msgid "Teaser"
@@ -196,22 +159,6 @@ msgstr "Simplelayout Standard-Konfiguration hinzufügen, siehe Dokumentation: ht
 #: ./ftw/simplelayout/contenttypes/behaviors.py:19
 msgid "description_teaser_fieldset"
 msgstr "Mit der Teaser-Funktion kann ein Block direkt mit weiterführendem Inhalt verknüpft werden.<br /> Der Titel und das Bild vom Block werden als Link mit dem Ziel verknüpft.<br /><br /> Oft wird die Teaserfunktion auch auf sogenannten Triage- oder Portal-Seiten verwendet. In diesen Fällen reicht ein Link in der Navigation nicht aus, sondern der Benutzer benötigt weitere Informationen, damit dieser auf der richten Seite landet."
-
-#: ./ftw/simplelayout/configure.zcml:63
-msgid "ftw.simplelayout development"
-msgstr ""
-
-#: ./ftw/simplelayout/configure.zcml:44
-msgid "ftw.simplelayout js library"
-msgstr ""
-
-#: ./ftw/simplelayout/mapblock/configure.zcml:21
-msgid "ftw.simplelayout mapblock default"
-msgstr ""
-
-#: ./ftw/simplelayout/contenttypes/configure.zcml:31
-msgid "ftw.simplelayout.contenttypes default"
-msgstr ""
 
 #. Default: "${title}, opens in a overlay."
 #: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:32
@@ -408,4 +355,5 @@ msgstr "Status"
 #, fuzzy
 msgid "title_delete_link_check"
 msgstr "Folgende Inhalte haben interne Links auf diesen Inhalt:"
+
 

--- a/ftw/simplelayout/locales/ftw.simplelayout-manual.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout-manual.pot
@@ -28,3 +28,6 @@ msgstr ""
 
 msgid "label_documentDate"
 msgstr ""
+
+msgid "Simplelayout View"
+msgstr ""

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-04 14:19+0000\n"
+"POT-Creation-Date: 2016-01-13 13:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,10 +26,6 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: ./ftw/simplelayout/contenttypes/configure.zcml:23
-msgid "Extends a content by two fields internal and external link"
-msgstr ""
-
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
 msgid "FileListingBlock"
 msgstr ""
@@ -47,10 +43,6 @@ msgstr ""
 msgid "It's not possible to have an internal_link and an external_link together"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:63
-msgid "Javascript resources from client are not compressed"
-msgstr ""
-
 #: ./ftw/simplelayout/mapblock/profiles/default/types/ftw.simplelayout.MapBlock.xml
 msgid "MapBlock"
 msgstr ""
@@ -59,24 +51,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: ./ftw/simplelayout/contenttypes/configure.zcml:31
-msgid "Simlelayout default content types"
-msgstr ""
-
-#: ./ftw/simplelayout/configure.zcml:44
-msgid "Simlelayout js library"
-msgstr ""
-
-#: ./ftw/simplelayout/mapblock/configure.zcml:21
-msgid "Simlelayout map block type"
-msgstr ""
-
-#: ./ftw/simplelayout/behaviors.zcml:18
-msgid "Simplelayout block behavior"
-msgstr ""
-
-#: ./ftw/simplelayout/behaviors.zcml:18
-msgid "Simplelayout block content marker"
+msgid "Simplelayout View"
 msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:82
@@ -88,20 +63,8 @@ msgstr ""
 msgid "Simplelayout default settings"
 msgstr ""
 
-#: ./ftw/simplelayout/behaviors.zcml:12
-msgid "Simplelayout page"
-msgstr ""
-
-#: ./ftw/simplelayout/behaviors.zcml:12
-msgid "Simplelayout page marker behavior"
-msgstr ""
-
 #: ./ftw/simplelayout/browser/controlpanel/simplelayout_controlpanel.py:16
 msgid "Simplelayout settings"
-msgstr ""
-
-#: ./ftw/simplelayout/contenttypes/configure.zcml:23
-msgid "Simplelayout teaser behavior"
 msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/behaviors.py:17
@@ -198,22 +161,6 @@ msgstr ""
 #. Default: "Use the teaser to redirect to another content or website.The title and the image of the block will be used to show a link"
 #: ./ftw/simplelayout/contenttypes/behaviors.py:19
 msgid "description_teaser_fieldset"
-msgstr ""
-
-#: ./ftw/simplelayout/configure.zcml:63
-msgid "ftw.simplelayout development"
-msgstr ""
-
-#: ./ftw/simplelayout/configure.zcml:44
-msgid "ftw.simplelayout js library"
-msgstr ""
-
-#: ./ftw/simplelayout/mapblock/configure.zcml:21
-msgid "ftw.simplelayout mapblock default"
-msgstr ""
-
-#: ./ftw/simplelayout/contenttypes/configure.zcml:31
-msgid "ftw.simplelayout.contenttypes default"
 msgstr ""
 
 #. Default: "${title}, opens in a overlay."
@@ -410,4 +357,5 @@ msgstr ""
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:37
 msgid "title_delete_link_check"
 msgstr ""
+
 


### PR DESCRIPTION
No uprade step:
On a customer installation we already had to configure this, otherwise simplelayout did not work properly, that's why I provide no upgrade step for this change