### PR TITLE
Use default table listing for the listingblock styles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Use default table listing for the listingblock styles.
+  Also implement some sane default withs for columns.
+  [mathias.leimgruber]
+
 - Add Simlelayout view as possible front page layout + addable types on the plone site.
   This change provides no upgrade step, since it may break the configuration.
   [mathias.leimgruber]

--- a/ftw/simplelayout/browser/resources/integration.default.css
+++ b/ftw/simplelayout/browser/resources/integration.default.css
@@ -305,6 +305,7 @@
   .sl-column.sl-col-2 {
     width: 100%;
   }
+}
 
 @media (min-width: 1360px) {
 
@@ -360,4 +361,37 @@
     margin-right: 0 !important;
   }
 
+}
+
+
+/* @group Filelistingblock */
+
+.sl-block.ftw-simplelayout-filelistingblock table tr th {
+  white-space: nowrap;
+  text-align: left;
+}
+
+.sl-block.ftw-simplelayout-filelistingblock table tr th.header-getObjSize {
+  text-align: right;
+}
+
+.sl-block.ftw-simplelayout-filelistingblock table tr td.column-modified {
+  width: 85px;
+}
+
+.sl-block.ftw-simplelayout-filelistingblock table tr td.column-portal_type {
+  width: 25px;
+  padding-right: 0;
+}
+
+.sl-block.ftw-simplelayout-filelistingblock table tr td.column-getObjSize {
+  width: 75px;
+}
+
+.sl-block.ftw-simplelayout-filelistingblock table tr td:last-child:not(.column-sortable_title) {
+  text-align: right;
+}
+
+.sl-block.ftw-simplelayout-filelistingblock table tr td img {
+  margin: 0;
 }

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -46,7 +46,7 @@
   opacity: 0;
 }
 
-
+// Galleryblock
 .galleryblockImageWrapper{
   display: table-cell;
   float: left;
@@ -74,4 +74,42 @@
 }
 .contenttreeWindow {
     z-index: 70001 !important;
+}
+
+// Listingblock
+.sl-block.ftw-simplelayout-filelistingblock {
+  table {
+    tr {
+      th {
+        white-space: nowrap;
+        text-align: left;
+        &.header-getObjSize {
+          text-align: right;
+        }
+      }
+      td {
+
+        &.column-modified {
+          width: 85px;
+        }
+
+        &.column-portal_type {
+          width: 25px;
+          padding-right: 0;
+        }
+
+        &.column-getObjSize {
+          width: 75px;
+        }
+
+        &:last-child:not(.column-sortable_title){
+          text-align: right;
+        }
+
+        img {
+          margin: 0;
+        }
+      }
+    }
+  }
 }

--- a/ftw/simplelayout/contenttypes/browser/filelistingblock.py
+++ b/ftw/simplelayout/contenttypes/browser/filelistingblock.py
@@ -50,7 +50,8 @@ class FileListingBlockView(BaseBlock):
         return generator.generate(
             self.get_table_contents(),
             list(self._filtered_columns()),
-            sortable=True,
+            sortable=False,
+            css_mapping={'table': 'listing nosort'},
             template=template,
             options={'table_summary': self.context.Title()},
             selected=(self._build_query['sort_on'],


### PR DESCRIPTION
- Implement some sane default withs for columns.
- Do not sort the table with js
![screen shot 2016-01-15 at 09 19 33](https://cloud.githubusercontent.com/assets/437933/12348662/8d5e6f0c-bb69-11e5-9b7b-74c6d9a107e1.png)
