### PR TITLE
Fix simplelayout dynamic scss resource, so it does not return invalid code if the selector is empty.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Fix simplelayout dynamic scss resource, so it does not return invalid code
+  if the selector is empty.
+  [mathias.leimgruber]
+
 - Use default table listing for the listingblock styles.
   Also implement some sane default withs for columns.
   [mathias.leimgruber]

--- a/ftw/simplelayout/browser/dynamic_scss_resources.py
+++ b/ftw/simplelayout/browser/dynamic_scss_resources.py
@@ -27,7 +27,12 @@ def hide_blocks_in_factory_menu(context, request):
 
     cachekey = hashlib.md5(''.join(selectors)).hexdigest()
 
+    if len(selectors):
+        source = TEMPLATE.format(', '.join(selectors))
+    else:
+        source = ''
+
     return DynamicSCSSResource('simplelayout_hide_blocks.scss',
                                slot='addon',
-                               source=TEMPLATE.format(', '.join(selectors)),
+                               source=source,
                                cachekey=cachekey)


### PR DESCRIPTION
This happens accentually, if ftw.simplelayout is in the PATH, but no installed.