### PR TITLE
Implement better image alt text for galleryblock and textblock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Implement better image alt text for galleryblock and textblock.
+  Improves Accessibility.
+  [mathias.leimgruber]
+
 - Right column overlapps the toolbar, apply fixed z-index.
   [Kevin Bieri]
 

--- a/ftw/simplelayout/contenttypes/browser/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/browser/galleryblock.py
@@ -29,7 +29,7 @@ class GalleryBlockView(BaseBlock):
 
     def generate_image_alttext(self, img):
         title = img.title_or_id().decode('utf-8')
-        return translate(_(u'galleryblock_link_title',
-                           default=u'${title}, opens in a overlay.',
+        return translate(_(u'image_link_alttext',
+                           default=u'${title}, enlarged picture.',
                            mapping={'title': title}),
                          context=self.request)

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-13 13:53+0000\n"
+"POT-Creation-Date: 2016-02-01 13:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -23,6 +23,10 @@ msgstr "Inhaltsseite"
 msgid "Delete"
 msgstr "Löschen"
 
+#: ./ftw/simplelayout/contenttypes/configure.zcml:24
+msgid "Extends a content by two fields internal and external link"
+msgstr ""
+
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
 msgid "FileListingBlock"
 msgstr "Dateiauflistung"
@@ -40,6 +44,10 @@ msgstr "ID"
 msgid "It's not possible to have an internal_link and an external_link together"
 msgstr "Es ist nicht möglich, einen internen und externen Link gleichzeitig zu definieren."
 
+#: ./ftw/simplelayout/configure.zcml:63
+msgid "Javascript resources from client are not compressed"
+msgstr ""
+
 #: ./ftw/simplelayout/mapblock/profiles/default/types/ftw.simplelayout.MapBlock.xml
 msgid "MapBlock"
 msgstr "Karte"
@@ -48,8 +56,29 @@ msgstr "Karte"
 msgid "Save"
 msgstr "Speichern"
 
+#: ./ftw/simplelayout/contenttypes/configure.zcml:32
+msgid "Simlelayout default content types"
+msgstr ""
+
+#: ./ftw/simplelayout/configure.zcml:44
+msgid "Simlelayout js library"
+msgstr ""
+
+#: ./ftw/simplelayout/mapblock/configure.zcml:21
+msgid "Simlelayout map block type"
+msgstr ""
+
+#: ./ftw/simplelayout/contenttypes/configure.zcml:46
 msgid "Simplelayout View"
 msgstr "Simplelayout Ansicht"
+
+#: ./ftw/simplelayout/behaviors.zcml:18
+msgid "Simplelayout block behavior"
+msgstr ""
+
+#: ./ftw/simplelayout/behaviors.zcml:18
+msgid "Simplelayout block content marker"
+msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:82
 msgid "Simplelayout default configuration"
@@ -60,9 +89,21 @@ msgstr "Simplelayout Standard-Konfiguration"
 msgid "Simplelayout default settings"
 msgstr "Simplelayout Standard-Einstellungen"
 
+#: ./ftw/simplelayout/behaviors.zcml:12
+msgid "Simplelayout page"
+msgstr ""
+
+#: ./ftw/simplelayout/behaviors.zcml:12
+msgid "Simplelayout page marker behavior"
+msgstr ""
+
 #: ./ftw/simplelayout/browser/controlpanel/simplelayout_controlpanel.py:16
 msgid "Simplelayout settings"
 msgstr "Simplelayout Einstellungen"
+
+#: ./ftw/simplelayout/contenttypes/configure.zcml:24
+msgid "Simplelayout teaser behavior"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/behaviors.py:17
 msgid "Teaser"
@@ -160,15 +201,32 @@ msgstr "Simplelayout Standard-Konfiguration hinzufügen, siehe Dokumentation: ht
 msgid "description_teaser_fieldset"
 msgstr "Mit der Teaser-Funktion kann ein Block direkt mit weiterführendem Inhalt verknüpft werden.<br /> Der Titel und das Bild vom Block werden als Link mit dem Ziel verknüpft.<br /><br /> Oft wird die Teaserfunktion auch auf sogenannten Triage- oder Portal-Seiten verwendet. In diesen Fällen reicht ein Link in der Navigation nicht aus, sondern der Benutzer benötigt weitere Informationen, damit dieser auf der richten Seite landet."
 
-#. Default: "${title}, opens in a overlay."
-#: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:32
-msgid "galleryblock_link_title"
-msgstr "${title}. Link öffnet das Bild in einem grösseren Fenster (Overlay)."
+#: ./ftw/simplelayout/configure.zcml:63
+msgid "ftw.simplelayout development"
+msgstr ""
+
+#: ./ftw/simplelayout/configure.zcml:44
+msgid "ftw.simplelayout js library"
+msgstr ""
+
+#: ./ftw/simplelayout/mapblock/configure.zcml:21
+msgid "ftw.simplelayout mapblock default"
+msgstr ""
+
+#: ./ftw/simplelayout/contenttypes/configure.zcml:32
+msgid "ftw.simplelayout.contenttypes default"
+msgstr ""
 
 #. Default: "Please drag, no click required"
 #: ./ftw/simplelayout/browser/ajax/toolbox_view.py:95
 msgid "help_drag_hint"
 msgstr "Bitte den Inhalt per Drag & Drop hinzufügen."
+
+#. Default: "${title}, enlarged picture."
+#: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:32
+#: ./ftw/simplelayout/contenttypes/browser/textblock.py:80
+msgid "image_link_alttext"
+msgstr "${title}. Vergrösserte Ansicht"
 
 #. Default: "Delete block"
 #: ./ftw/simplelayout/browser/actions.py:37
@@ -352,8 +410,6 @@ msgstr "Status"
 
 #. Default: "These internal links will be broken"
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:37
-#, fuzzy
 msgid "title_delete_link_check"
 msgstr "Folgende Inhalte haben interne Links auf diesen Inhalt:"
-
 

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-01-13 13:53+0000\n"
+"POT-Creation-Date: 2016-02-01 13:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,6 +26,10 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
+#: ./ftw/simplelayout/contenttypes/configure.zcml:24
+msgid "Extends a content by two fields internal and external link"
+msgstr ""
+
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
 msgid "FileListingBlock"
 msgstr ""
@@ -43,6 +47,10 @@ msgstr ""
 msgid "It's not possible to have an internal_link and an external_link together"
 msgstr ""
 
+#: ./ftw/simplelayout/configure.zcml:63
+msgid "Javascript resources from client are not compressed"
+msgstr ""
+
 #: ./ftw/simplelayout/mapblock/profiles/default/types/ftw.simplelayout.MapBlock.xml
 msgid "MapBlock"
 msgstr ""
@@ -51,7 +59,28 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: ./ftw/simplelayout/contenttypes/configure.zcml:32
+msgid "Simlelayout default content types"
+msgstr ""
+
+#: ./ftw/simplelayout/configure.zcml:44
+msgid "Simlelayout js library"
+msgstr ""
+
+#: ./ftw/simplelayout/mapblock/configure.zcml:21
+msgid "Simlelayout map block type"
+msgstr ""
+
+#: ./ftw/simplelayout/contenttypes/configure.zcml:46
 msgid "Simplelayout View"
+msgstr ""
+
+#: ./ftw/simplelayout/behaviors.zcml:18
+msgid "Simplelayout block behavior"
+msgstr ""
+
+#: ./ftw/simplelayout/behaviors.zcml:18
+msgid "Simplelayout block content marker"
 msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:82
@@ -63,8 +92,20 @@ msgstr ""
 msgid "Simplelayout default settings"
 msgstr ""
 
+#: ./ftw/simplelayout/behaviors.zcml:12
+msgid "Simplelayout page"
+msgstr ""
+
+#: ./ftw/simplelayout/behaviors.zcml:12
+msgid "Simplelayout page marker behavior"
+msgstr ""
+
 #: ./ftw/simplelayout/browser/controlpanel/simplelayout_controlpanel.py:16
 msgid "Simplelayout settings"
+msgstr ""
+
+#: ./ftw/simplelayout/contenttypes/configure.zcml:24
+msgid "Simplelayout teaser behavior"
 msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/behaviors.py:17
@@ -163,14 +204,31 @@ msgstr ""
 msgid "description_teaser_fieldset"
 msgstr ""
 
-#. Default: "${title}, opens in a overlay."
-#: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:32
-msgid "galleryblock_link_title"
+#: ./ftw/simplelayout/configure.zcml:63
+msgid "ftw.simplelayout development"
+msgstr ""
+
+#: ./ftw/simplelayout/configure.zcml:44
+msgid "ftw.simplelayout js library"
+msgstr ""
+
+#: ./ftw/simplelayout/mapblock/configure.zcml:21
+msgid "ftw.simplelayout mapblock default"
+msgstr ""
+
+#: ./ftw/simplelayout/contenttypes/configure.zcml:32
+msgid "ftw.simplelayout.contenttypes default"
 msgstr ""
 
 #. Default: "Please drag, no click required"
 #: ./ftw/simplelayout/browser/ajax/toolbox_view.py:95
 msgid "help_drag_hint"
+msgstr ""
+
+#. Default: "${title}, enlarged picture."
+#: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:32
+#: ./ftw/simplelayout/contenttypes/browser/textblock.py:80
+msgid "image_link_alttext"
 msgstr ""
 
 #. Default: "Delete block"
@@ -357,5 +415,4 @@ msgstr ""
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:37
 msgid "title_delete_link_check"
 msgstr ""
-
 

--- a/ftw/simplelayout/tests/test_textblock_view.py
+++ b/ftw/simplelayout/tests/test_textblock_view.py
@@ -187,7 +187,8 @@ class TestTextBlockRendering(TestCase):
                        .having(text=RichTextValue('The text'))
                        .having(image=NamedBlobImage(data=self.image.read(),
                                                     filename=u'test.gif'))
-                       .having(open_image_in_overlay=True))
+                       .having(open_image_in_overlay=True,
+                               ))
 
         browser.login().visit(block, view='@@block_view')
         link_url = browser.css('a.colorboxLink').first.attrib['href']
@@ -226,3 +227,20 @@ class TestTextBlockRendering(TestCase):
             [],
             browser.css('a.colorboxLink')
         )
+
+    @browsing
+    def test_auto_appending_enlarged_picture_for_overlay(self, browser):
+        block = create(Builder('sl textblock')
+                       .within(self.page)
+                       .titled('TextBlock title')
+                       .having(text=RichTextValue('The text'))
+                       .having(image=NamedBlobImage(data=self.image.read(),
+                                                    filename=u'test.gif'))
+                       .having(open_image_in_overlay=True,
+                               image_alt_text='Some alt text'))
+
+        browser.login().visit(block, view='@@block_view')
+        self.assertTrue(
+            browser.css('a.colorboxLink').first.attrib['title'].endswith(
+                'enlarged picture.'),
+            'Expect "enlarged picture." hint in alt text of img.')


### PR DESCRIPTION
Automatically add "enlarged picture" to links, which opens in a overlay. 

This changes improves the accessiblity (screen reader).