### PR TITLE
Right column overlapps the toolbar.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Right column overlapps the toolbar, apply fixed z-index.
+  [Kevin Bieri]
+
 - Move styling from client library to ftw.theming integration using
   base variables from ftw.theming.
   [Kevin Bieri]

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -234,6 +234,7 @@ ul[class^="sl-toolbar"] {
   background-color: $color-edit;
   visibility: hidden;
   border-radius: $border-radius-primary;
+  z-index: 1;
   li {
     text-align: center;
     a {


### PR DESCRIPTION
Fixes https://github.com/OneGov/plonetheme.onegovbear/issues/110

The gridsystem works with relative positioned containers. The right
column comes after the content column to the portletcolumn on the right
overlapps the content. To make sure the toolbar is always on top
apply a fixed z-index.

![bildschirmfoto 2016-02-03 um 08 41 02](https://cloud.githubusercontent.com/assets/1637820/12775974/6d576540-ca52-11e5-8735-c8e41d0f74b5.png)