### PR TITLE
Respect disable_border key in request and do not load simplelayout if present.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Respect disable_border key in request and do not load simplelayout if present.
+  [mathias.leimgruber]
+
 - Remove leadimage cache key. [jone]
 
 - Show hint on empty listing and galeryblock.

--- a/ftw/simplelayout/browser/provider.py
+++ b/ftw/simplelayout/browser/provider.py
@@ -157,9 +157,12 @@ class BaseSimplelayoutExpression(object):
         settings['canChangeLayout'] = api.user.has_permission(
             'ftw.simplelayout: Change Layouts',
             obj=self.context)
+
+        # Check if disable_border is in request, if it's there do not load
+        # simplelayout.
         settings['canEdit'] = api.user.has_permission(
             'Modify portal content',
-            obj=self.context)
+            obj=self.context) and int(self.request.get('disable_border', 0)) == 0
 
 
 class SimplelayoutExpression(BaseSimplelayoutExpression,

--- a/ftw/simplelayout/portlets/portlet.py
+++ b/ftw/simplelayout/portlets/portlet.py
@@ -30,8 +30,9 @@ class Renderer(base.Renderer):
         if self.has_blocks():
             return True
         else:
+            disabled = int(self.request.get('disable_border', 0)) == 1
             return api.user.has_permission('Modify portal content',
-                                           obj=self.context)
+                                           obj=self.context) and not disabled
 
     def has_blocks(self):
         config = IPageConfiguration(self.context)

--- a/ftw/simplelayout/tests/test_simplelayout_portlet.py
+++ b/ftw/simplelayout/tests/test_simplelayout_portlet.py
@@ -91,3 +91,11 @@ class TestSimplelayoutView(SimplelayoutTestCase):
 
         self.assertFalse(browser.css('.portlet.SimplelayoutPortlet'),
                          'Portlet is empty and should not be visible')
+
+    @browsing
+    def test_portlet_is_not_visible_when_empty_and_disable_border_is_true(self, browser):
+        self.setup_portlet()
+        browser.login().visit(self.container, data={'disable_border': 1})
+
+        self.assertFalse(browser.css('.portlet.SimplelayoutPortlet'),
+                         'Portlet is empty and should not be visible')

--- a/ftw/simplelayout/tests/test_simplelayout_view.py
+++ b/ftw/simplelayout/tests/test_simplelayout_view.py
@@ -384,3 +384,12 @@ class TestSimplelayoutView(SimplelayoutTestCase):
             ['SampleBlock'],
             view.addable_block_types()
         )
+
+    @browsing
+    def test_canEdit_is_false_if_border_disabled(self, browser):
+        browser.login().visit(self.container, data={'disable_border': 1})
+        data_attr_value = json.loads(browser.css(
+            '[data-sl-settings]').first.attrib['data-sl-settings'])
+
+        self.assertFalse(data_attr_value['canEdit'],
+                         'Edit should be disabled if disable_border is there.')


### PR DESCRIPTION
On `REQUEST.set('disable_border', '1')` the simplelayout toolset is not loaded. 
This is a default plone feature. 

This also affects the simplelayout portlet:
If the portlet is empty and disable_border=1 do not show the portlet. 