### PR TITLE
Remove leadimage cache key.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Remove leadimage cache key. [jone]
+
 - Show hint on empty listing and galeryblock.
   [mathias.leimgruber]
 

--- a/ftw/simplelayout/contenttypes/browser/leadimage.py
+++ b/ftw/simplelayout/contenttypes/browser/leadimage.py
@@ -2,18 +2,9 @@ from ftw.simplelayout.contenttypes.contents.interfaces import ITextBlock
 from ftw.simplelayout.handlers import unwrap_persistence
 from ftw.simplelayout.interfaces import IPageConfiguration
 from plone.app.uuid.utils import uuidToObject
-from plone.memoize import ram
 from Products.Five.browser import BrowserView
-import hashlib
 import json
 import re
-
-
-def _render_cachkey(method, self):
-    key = (str(self.context.modified().millis()),
-           self.request.get('scale', ''),
-           __name__ + method.__name__)
-    return hashlib.md5(';'.join(key)).hexdigest()
 
 
 class LeadImageView(BrowserView):
@@ -23,7 +14,6 @@ class LeadImageView(BrowserView):
     has_image = None
     block = None
 
-    @ram.cache(_render_cachkey)
     def __call__(self):
         self._get_image()
 


### PR DESCRIPTION
The cachekey currently includes the full URL to the image.
This is problematic since the URL may change depending how the site is
accessed (VirtualHostMonster, port tunneling).

The second problem is that the cache key does not include the page. This
may lead to the wrong image beeing displayed when multiple pages are
modified at the exact same time.

Since this is cache is probably a premature optimization I'm just
removing it. We can implement a new one when we are in need.