### PR TITLE
Configure TinyMCE resource types.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
+- Configure TinyMCE resource types. [jone]
+
 - Respect disable_border key in request and do not load simplelayout if present.
   [mathias.leimgruber]
 

--- a/ftw/simplelayout/contenttypes/profiles/default/tinymce.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default/tinymce.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0"?>
 <object>
- <resourcetypes>
-  <linkable purge="False">
-   <element value="ftw.simplelayout.ContentPage"/>
-  </linkable>
-  <containsobjects purge="False">
-   <element value="ftw.simplelayout.ContentPage"/>
-  </containsobjects>
- </resourcetypes>
+    <resourcetypes>
+
+        <linkable purge="False">
+            <element value="ftw.simplelayout.ContentPage"/>
+            <element value="ftw.simplelayout.FileListingBlock"/>
+            <element value="ftw.simplelayout.GalleryBlock"/>
+            <element value="ftw.simplelayout.TextBlock"/>
+            <element value="ftw.simplelayout.VideoBlock"/>
+        </linkable>
+
+        <containsobjects purge="False">
+            <element value="ftw.simplelayout.ContentPage"/>
+            <element value="ftw.simplelayout.FileListingBlock"/>
+            <element value="ftw.simplelayout.GalleryBlock"/>
+        </containsobjects>
+
+    </resourcetypes>
 </object>

--- a/ftw/simplelayout/mapblock/profiles/default/tinymce.xml
+++ b/ftw/simplelayout/mapblock/profiles/default/tinymce.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object>
+    <resourcetypes>
+
+        <linkable purge="False">
+            <element value="ftw.simplelayout.MapBlock"/>
+        </linkable>
+
+    </resourcetypes>
+</object>


### PR DESCRIPTION
Configure TinyMCE so that the page and the blocks are linkable in TinyMCE and the folderish types (page, listing and gallery blocks) can be opened for linking their contents.