### PR TITLE
Fix exception when form folder is deleted.

### DIFF
--- a/ftw/simplelayout/handlers.py
+++ b/ftw/simplelayout/handlers.py
@@ -60,6 +60,9 @@ def update_page_state_on_block_remove(block, event):
         if parent is not event.oldParent:
             return
 
+        if not ISimplelayout.providedBy(parent):
+            return
+
         config = IPageConfiguration(parent)
         page_state = config.load()
 

--- a/sources.cfg
+++ b/sources.cfg
@@ -14,3 +14,4 @@ auto-checkout =
 
 [branches]
 ftw.testbrowser = mle-pawtextwidget
+ftw.theming = amnesty-production


### PR DESCRIPTION
The portal type `FormFolder` has been turned into a simpleyalyout block in the amnesty.ch project. Deleting such a form folder causes an exception because of a handler in `ftw.simplylayout`. This handler tries to adapt the parent of the form folder with `IPageConfiguration`. This will fail if the parent of the form folder is a folder.

See https://basecamp.com/2768704/projects/9428894/todos/238322959 