### PR TITLE
Reset default scale behavior for textblock images.

### DIFF
--- a/ftw/simplelayout/contenttypes/browser/textblock.py
+++ b/ftw/simplelayout/contenttypes/browser/textblock.py
@@ -105,7 +105,7 @@ class TextBlockView(BaseBlock):
         if not scale:
             scale = self._get_image_scale_name()
         scaler = self.context.restrictedTraverse('@@images')
-        return scaler.scale('image', scale=scale, direction='down')
+        return scaler.scale('image', scale=scale)
 
     @memoize
     def _get_default_actions(self):


### PR DESCRIPTION
Closes https://github.com/4teamwork/bl.web/issues/74

Changing the scale behavior in
https://github.com/4teamwork/ftw.simplelayout/commit/23b6cbbf5e8302637dcf06db55e3d2afc6ccc49a
for simplelayout textblock images may be confusing for the user.
The user is responsible himself to upload proper images with fitting aspect ratio.