### PR TITLE
Some blocks can be hidden now.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Some blocks can be hidden now. Users allowed to edit the block will see
+  the block anyway.
+  [mbaechtold]
 
 
 1.2.0 (2016-03-30)

--- a/ftw/simplelayout/browser/provider.py
+++ b/ftw/simplelayout/browser/provider.py
@@ -59,27 +59,38 @@ class BaseSimplelayoutExpression(object):
 
                 for block in col['blocks']:
                     obj = blocks[block['uid']]
-                    block['obj_html'] = self._render_block_html(obj)
-                    block['type'] = normalize_portal_type(obj.portal_type)
-                    block['url'] = obj.absolute_url()
-                    block['id'] = obj.getId()
+                    self.create_or_update_block(obj, block)
 
         # Append blocks, which are not in the simplelayout configuration into
         # the last column.
 
         if self.name == 'default':
             for uid, obj in self._blocks_without_state():
-                rows[-1]['cols'][-1]['blocks'].append(
-                    {
-                        'uid': uid,
-                        'obj_html': self._render_block_html(obj),
-                        'type': normalize_portal_type(obj.portal_type),
-                        'url': obj.absolute_url(),
-                        'id': obj.getId(),
-                    }
-                )
+                block = self.create_or_update_block(obj, uid=uid)
+                rows[-1]['cols'][-1]['blocks'].append(block)
 
         return rows
+
+    def create_or_update_block(self, obj, block_dict=None, uid=None):
+        if not block_dict:
+            block_dict = {}
+
+        if uid:
+            block_dict['uid'] = uid
+
+        block_type = normalize_portal_type(obj.portal_type)
+
+        css_classes = ['sl-block', block_type]
+        if getattr(obj, 'is_hidden', False):
+            css_classes.append('hidden')
+
+        block_dict['obj_html'] = self._render_block_html(obj)
+        block_dict['type'] = block_type
+        block_dict['url'] = obj.absolute_url()
+        block_dict['id'] = obj.getId()
+        block_dict['css_classes'] = ' '.join(css_classes)
+
+        return block_dict
 
     def _get_first_column_config(self):
         settings = self._get_sl_settings()

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -117,6 +117,9 @@
     z-index: 1000;
     background-color: $color-content-background;
   }
+  &.hidden {
+    display: none;
+  }
 }
 
 .sl-block-dragging {
@@ -402,6 +405,10 @@ ul[class^="sl-toolbar"] {
     @include transition(box-shadow .3s ease-out);
     &:hover {
       @include boxshadow(0 0 20px 0 $color-edit);
+    }
+    &.hidden {
+      display: block;
+      @include boxshadow(0 0 20px 0 $color-warning);
     }
   }
 }

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -117,9 +117,6 @@
     z-index: 1000;
     background-color: $color-content-background;
   }
-  &.hidden {
-    display: none;
-  }
 }
 
 .sl-block-dragging {
@@ -407,7 +404,6 @@ ul[class^="sl-toolbar"] {
       @include boxshadow(0 0 20px 0 $color-edit);
     }
     &.hidden {
-      display: block;
       @include boxshadow(0 0 20px 0 $color-warning);
     }
   }

--- a/ftw/simplelayout/browser/templates/structure.pt
+++ b/ftw/simplelayout/browser/templates/structure.pt
@@ -9,7 +9,7 @@
          tal:repeat="col row/cols"
          tal:attributes="class col/class">
       <tal:blocks tal:repeat="block col/blocks">
-        <div tal:attributes="class string:sl-block ${block/type};
+        <div tal:attributes="class block/css_classes;
                              data-type block/type;
                              data-uid block/uid;
                              data-url block/url;">

--- a/ftw/simplelayout/contenttypes/contents/filelistingblock.py
+++ b/ftw/simplelayout/contenttypes/contents/filelistingblock.py
@@ -157,6 +157,16 @@ class IFileListingBlockSchema(form.Schema):
         default="ascending",
         vocabulary=sort_order_vocabulary)
 
+    is_hidden = schema.Bool(
+        title=_(u'label_is_hidden', default=u'Hide the block'),
+        description=_(
+            u'description_is_hidden',
+            default=u'This will visually hide the block. This is not a '
+                    u'security feature, the block and its content can '
+                    u'still be accessed.'),
+        default=False,
+        required=False)
+
 
 alsoProvides(IFileListingBlockSchema, IFormFieldProvider)
 

--- a/ftw/simplelayout/contenttypes/contents/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/contents/galleryblock.py
@@ -24,6 +24,16 @@ class IGalleryBlockSchema(form.Schema):
         default=True,
         required=False)
 
+    is_hidden = schema.Bool(
+        title=_(u'label_is_hidden', default=u'Hide the block'),
+        description=_(
+            u'description_is_hidden',
+            default=u'This will visually hide the block. This is not a '
+                    u'security feature, the block and its content can '
+                    u'still be accessed.'),
+        default=False,
+        required=False)
+
 
 alsoProvides(IGalleryBlockSchema, IFormFieldProvider)
 

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-08 08:13+0000\n"
+"POT-Creation-Date: 2016-04-08 08:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -197,6 +197,12 @@ msgstr "Typ"
 msgid "desc_sl_config_control_panel"
 msgstr "Simplelayout Standard-Konfiguration hinzufügen, siehe Dokumentation: https://github.com/4teamwork/ftw.simplelayout#usage"
 
+#. Default: "This will visually hide the block. This is not a security feature, the block and its content can still be accessed."
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:162
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:29
+msgid "description_is_hidden"
+msgstr "Dies versteckt den Block rein visuell. Dies ist kein Sicherheits-Feature, der Block und sein Inhalt bleibt immer noch aufrufbar."
+
 #. Default: "Use the teaser to redirect to another content or website.The title and the image of the block will be used to show a link"
 #: ./ftw/simplelayout/contenttypes/behaviors.py:19
 msgid "description_teaser_fieldset"
@@ -303,12 +309,12 @@ msgid "label_float_large_image_right"
 msgstr "Grosses Bild rechts ausrichten"
 
 #. Default: "Go to folder contents for managing files"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:187
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:192
 msgid "label_folder_contents_files"
 msgstr "Dateien über Inhalte verwalten."
 
 #. Default: "Go to folder contents for managing images"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:54
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:59
 msgid "label_folder_contents_images"
 msgstr "Bilder über Inhalte verwalten."
 
@@ -334,6 +340,12 @@ msgstr "Bild ohne Ausrichtung"
 #: ./ftw/simplelayout/contenttypes/behaviors.py:32
 msgid "label_internal_link"
 msgstr "Interne Referenz"
+
+#. Default: "Hide the block"
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:161
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:28
+msgid "label_is_hidden"
+msgstr "Block verstecken"
 
 msgid "label_modified"
 msgstr "Bearbeitungsdatum"
@@ -394,8 +406,8 @@ msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Upload"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:180
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:47
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:185
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:52
 msgid "label_upload"
 msgstr "Datei hochladen"
 

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-01 13:26+0000\n"
+"POT-Creation-Date: 2016-04-08 08:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -130,6 +130,7 @@ msgid "The video block renders videos loaded from YouTube or Vimeo."
 msgstr "Der Video-Block zeigt Videos von YouTube oder Vimeo an."
 
 #: ./ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt:8
+#: ./ftw/simplelayout/contenttypes/browser/templates/listingblock.pt:10
 #: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:26
 msgid "This block is empty."
 msgstr "Dieser Block hat keinen Inhalt."
@@ -224,7 +225,7 @@ msgstr "Bitte den Inhalt per Drag & Drop hinzufügen."
 
 #. Default: "${title}, enlarged picture."
 #: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:32
-#: ./ftw/simplelayout/contenttypes/browser/textblock.py:80
+#: ./ftw/simplelayout/contenttypes/browser/textblock.py:83
 msgid "image_link_alttext"
 msgstr "${title}. Vergrösserte Ansicht"
 
@@ -302,12 +303,12 @@ msgid "label_float_large_image_right"
 msgstr "Grosses Bild rechts ausrichten"
 
 #. Default: "Go to folder contents for managing files"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:182
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:187
 msgid "label_folder_contents_files"
 msgstr "Dateien über Inhalte verwalten."
 
 #. Default: "Go to folder contents for managing images"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:49
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:54
 msgid "label_folder_contents_images"
 msgstr "Bilder über Inhalte verwalten."
 
@@ -393,8 +394,8 @@ msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Upload"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:175
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:42
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:180
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:47
 msgid "label_upload"
 msgstr "Datei hochladen"
 

--- a/ftw/simplelayout/locales/ftw.simplelayout-manual.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout-manual.pot
@@ -28,6 +28,3 @@ msgstr ""
 
 msgid "label_documentDate"
 msgstr ""
-
-msgid "Simplelayout View"
-msgstr ""

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-02-01 13:26+0000\n"
+"POT-Creation-Date: 2016-04-08 08:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -133,6 +133,7 @@ msgid "The video block renders videos loaded from YouTube or Vimeo."
 msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt:8
+#: ./ftw/simplelayout/contenttypes/browser/templates/listingblock.pt:10
 #: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:26
 msgid "This block is empty."
 msgstr ""
@@ -227,7 +228,7 @@ msgstr ""
 
 #. Default: "${title}, enlarged picture."
 #: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:32
-#: ./ftw/simplelayout/contenttypes/browser/textblock.py:80
+#: ./ftw/simplelayout/contenttypes/browser/textblock.py:83
 msgid "image_link_alttext"
 msgstr ""
 
@@ -305,12 +306,12 @@ msgid "label_float_large_image_right"
 msgstr ""
 
 #. Default: "Go to folder contents for managing files"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:182
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:187
 msgid "label_folder_contents_files"
 msgstr ""
 
 #. Default: "Go to folder contents for managing images"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:49
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:54
 msgid "label_folder_contents_images"
 msgstr ""
 
@@ -396,8 +397,8 @@ msgid "label_title"
 msgstr ""
 
 #. Default: "Upload"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:175
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:42
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:180
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:47
 msgid "label_upload"
 msgstr ""
 

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-08 08:13+0000\n"
+"POT-Creation-Date: 2016-04-08 08:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -200,6 +200,12 @@ msgstr ""
 msgid "desc_sl_config_control_panel"
 msgstr ""
 
+#. Default: "This will visually hide the block. This is not a security feature, the block and its content can still be accessed."
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:162
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:29
+msgid "description_is_hidden"
+msgstr ""
+
 #. Default: "Use the teaser to redirect to another content or website.The title and the image of the block will be used to show a link"
 #: ./ftw/simplelayout/contenttypes/behaviors.py:19
 msgid "description_teaser_fieldset"
@@ -306,12 +312,12 @@ msgid "label_float_large_image_right"
 msgstr ""
 
 #. Default: "Go to folder contents for managing files"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:187
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:192
 msgid "label_folder_contents_files"
 msgstr ""
 
 #. Default: "Go to folder contents for managing images"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:54
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:59
 msgid "label_folder_contents_images"
 msgstr ""
 
@@ -336,6 +342,12 @@ msgstr ""
 #. Default: "Internal link"
 #: ./ftw/simplelayout/contenttypes/behaviors.py:32
 msgid "label_internal_link"
+msgstr ""
+
+#. Default: "Hide the block"
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:161
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:28
+msgid "label_is_hidden"
 msgstr ""
 
 msgid "label_modified"
@@ -397,8 +409,8 @@ msgid "label_title"
 msgstr ""
 
 #. Default: "Upload"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:180
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:47
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:185
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:52
 msgid "label_upload"
 msgstr ""
 

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -145,7 +145,8 @@ class TestGalleryBlock(TestCase):
     def test_hidden_galleryblock_has_special_class(self, browser):
         """
         This test makes sure that a special class is available on the block
-        if the block is hidden.
+        if the block is hidden. This can be used to visually highlight
+        hidden blocks.
         """
         galleryblock = create(Builder('sl galleryblock')
                               .titled('My galleryblock')
@@ -173,4 +174,30 @@ class TestGalleryBlock(TestCase):
         self.assertEqual(
             'sl-block ftw-simplelayout-galleryblock',
             browser.css('.ftw-simplelayout-galleryblock').first.attrib['class']
+        )
+
+    @browsing
+    def test_hidden_galleryblock_not_visible_without_edit_permission(self, browser):
+        """
+        This test makes sure that users without edit permission, e.g. the
+        anonymous user, do not see the hidden block.
+        """
+        galleryblock = create(Builder('sl galleryblock')
+                              .titled('My galleryblock')
+                              .having(show_title=True)
+                              .having(is_hidden=True)
+                              .within(self.page))
+
+        # Make sure an anonymous user cannot see the block.
+        browser.logout().visit(self.page)
+        self.assertEqual(
+            [],
+            browser.css('.ftw-simplelayout-galleryblock')
+        )
+
+        # Login to make sure the block is visible for admin users.
+        browser.login().visit(self.page)
+        self.assertEqual(
+            ['My galleryblock'],
+            browser.css('.ftw-simplelayout-galleryblock h2').text
         )

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -140,3 +140,37 @@ class TestGalleryBlock(TestCase):
         transaction.commit()
         browser.login().visit(self.page)
         self.assertEqual([], browser.css(title_css_selector))
+
+    @browsing
+    def test_hidden_galleryblock_has_special_class(self, browser):
+        """
+        This test makes sure that a special class is available on the block
+        if the block is hidden.
+        """
+        galleryblock = create(Builder('sl galleryblock')
+                              .titled('My galleryblock')
+                              .having(show_title=True)
+                              .having(is_hidden=True)
+                              .within(self.page))
+
+        browser.login()
+
+        # The block must have a class "hidden".
+        browser.visit(self.page)
+        self.assertEqual(
+            'sl-block ftw-simplelayout-galleryblock hidden',
+            browser.css('.ftw-simplelayout-galleryblock').first.attrib['class']
+        )
+
+        # Edit the block and make appear again.
+        browser.visit(galleryblock, view='edit.json')
+        response = browser.json
+        browser.open_html(response['content'])
+        browser.fill({'Hide the block': False}).submit()
+
+        # The block must no longer have a class "hidden".
+        browser.visit(self.page)
+        self.assertEqual(
+            'sl-block ftw-simplelayout-galleryblock',
+            browser.css('.ftw-simplelayout-galleryblock').first.attrib['class']
+        )

--- a/ftw/simplelayout/tests/test_listingblock.py
+++ b/ftw/simplelayout/tests/test_listingblock.py
@@ -143,7 +143,8 @@ class TestListingBlock(TestCase):
     def test_hidden_listingblock_has_special_class(self, browser):
         """
         This test makes sure that a special class is available on the block
-        if the block is hidden.
+        if the block is hidden. This can be used to visually highlight
+        hidden blocks.
         """
         listingblock = create(Builder('sl listingblock')
                               .titled('My listingblock')
@@ -171,4 +172,30 @@ class TestListingBlock(TestCase):
         self.assertEqual(
             'sl-block ftw-simplelayout-filelistingblock',
             browser.css('.ftw-simplelayout-filelistingblock').first.attrib['class']
+        )
+
+    @browsing
+    def test_hidden_listingblock_not_visible_without_edit_permission(self, browser):
+        """
+        This test makes sure that users without edit permission, e.g. the
+        anonymous user, do not see the hidden block.
+        """
+        listingblock = create(Builder('sl listingblock')
+                              .titled('My listingblock')
+                              .having(show_title=True)
+                              .having(is_hidden=True)
+                              .within(self.page))
+
+        # Make sure an anonymous user cannot see the block.
+        browser.logout().visit(self.page)
+        self.assertEqual(
+            [],
+            browser.css('.ftw-simplelayout-filelistingblock')
+        )
+
+        # Login to make sure the block is visible for admin users.
+        browser.login().visit(self.page)
+        self.assertEqual(
+            ['My listingblock'],
+            browser.css('.ftw-simplelayout-filelistingblock h2').text
         )

--- a/ftw/simplelayout/tests/test_listingblock.py
+++ b/ftw/simplelayout/tests/test_listingblock.py
@@ -138,3 +138,37 @@ class TestListingBlock(TestCase):
         transaction.commit()
         browser.login().visit(self.page)
         self.assertEqual([], browser.css(title_css_selector))
+
+    @browsing
+    def test_hidden_listingblock_has_special_class(self, browser):
+        """
+        This test makes sure that a special class is available on the block
+        if the block is hidden.
+        """
+        listingblock = create(Builder('sl listingblock')
+                              .titled('My listingblock')
+                              .having(show_title=True)
+                              .having(is_hidden=True)
+                              .within(self.page))
+
+        browser.login()
+
+        # The block must have a class "hidden".
+        browser.visit(self.page)
+        self.assertEqual(
+            'sl-block ftw-simplelayout-filelistingblock hidden',
+            browser.css('.ftw-simplelayout-filelistingblock').first.attrib['class']
+        )
+
+        # Edit the block and make appear again.
+        browser.visit(listingblock, view='edit.json')
+        response = browser.json
+        browser.open_html(response['content'])
+        browser.fill({'Hide the block': False, 'Columns': 'Type'}).submit()
+
+        # The block must no longer have a class "hidden".
+        browser.visit(self.page)
+        self.assertEqual(
+            'sl-block ftw-simplelayout-filelistingblock',
+            browser.css('.ftw-simplelayout-filelistingblock').first.attrib['class']
+        )


### PR DESCRIPTION
Hidden blocks will not be shown on its simplelayout container if the user does not have the permission to edit content.

Users allowed to edit the block will see the block anyway (highlighted).

This is not a security feature, the block and its content can still be accessed if the path is known.