### PR TITLE
Fix gallery spacing in gallery grid.

### DIFF
--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -410,7 +410,7 @@ ul[class^="sl-toolbar"] {
 }
 
 .galleryblockImageWrapper {
-  @include floatgrid(4);
+  @include floatgrid(4, $by-index: false);
   margin-bottom: $margin-vertical;
   > a {
     display: block;


### PR DESCRIPTION
Closes https://github.com/4teamwork/bl.web/issues/93

<img width="1229" alt="bildschirmfoto 2016-04-15 um 09 58 57" src="https://cloud.githubusercontent.com/assets/1637820/14555064/b42453d0-02f0-11e6-9c57-e1b02f703822.png">
