### PR TITLE
Remove "Review State" column from file listing block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove "Review State" column from file listing block.
+  It is usually not in use, since files has no workflow on simplelayout sites.
+  [mathias.leimgruber]
 
 
 1.2.1 (2016-04-14)

--- a/ftw/simplelayout/contenttypes/contents/filelistingblock.py
+++ b/ftw/simplelayout/contenttypes/contents/filelistingblock.py
@@ -66,11 +66,6 @@ class ListingBlockDefaultColumns(object):
              'column_title': _(u'column_size', default=u'size'),
              },
 
-            {'column': 'review_state',
-             'column_title': _(u'review_state', default=u'Review State'),
-             'transform': helper.translated_string(),
-             },
-
             {'column': 'id',
              'column_title': _(u'ID', default=u'ID'),
              'sort_index': 'id',

--- a/ftw/simplelayout/tests/test_listingblock.py
+++ b/ftw/simplelayout/tests/test_listingblock.py
@@ -60,7 +60,7 @@ class TestListingBlock(TestCase):
         factoriesmenu.add('FileListingBlock')
 
         self.assertEquals(
-            ['creater', 'size', 'Review State', 'ID'],
+            ['creater', 'size', 'ID'],
             browser.css('#form-widgets-columns-from option').text)
 
         self.assertEquals(


### PR DESCRIPTION
Files has no WF on simplelayout sites, since the files belongs directly to site itself. 
Thus we remove the `Review State` column by default. 

This also fixes a issue if the review state column is active and workflow for files is present:


```
2016-04-08 08:26:59 ERROR Zope.SiteErrorLog 1460096819.890.249324806379 http://localhost:8080/platform2/politik-und-behorden/direktionen/finanz-und-kirchendirektion/finanzverwaltung/finanzkennzahlen/downloads/edit.json
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module z3c.form.form, line 224, in __call__
  Module ftw.simplelayout.browser.ajax.edit_block, line 59, in render
  Module ftw.simplelayout.utils, line 20, in get_block_html
  Module ftw.simplelayout.browser.blocks.base, line 18, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module zope.pagetemplate.pagetemplate, line 240, in __call__
  Module zope.tal.talinterpreter, line 271, in __call__
  Module zope.tal.talinterpreter, line 343, in interpret
  Module zope.tal.talinterpreter, line 531, in do_optTag_tal
  Module zope.tal.talinterpreter, line 513, in no_tag
  Module zope.tal.talinterpreter, line 343, in interpret
  Module zope.tal.talinterpreter, line 531, in do_optTag_tal
  Module zope.tal.talinterpreter, line 513, in no_tag
  Module zope.tal.talinterpreter, line 343, in interpret
  Module zope.tal.talinterpreter, line 742, in do_insertStructure_tal
  Module Products.PageTemplates.Expressions, line 218, in evaluateStructure
  Module zope.tales.tales, line 696, in evaluate
   - URL: /Users/jone/projects/packages/bl.web/src/ftw.simplelayout/ftw/simplelayout/contenttypes/browser/templates/listingblock.pt
   - Line 9, Column 4
   - Expression: <PathExpr standard:u'view/render_table'>
   - Names:
      {'args': (),
       'container': <FileListingBlock at /platform2/politik-und-behorden/direktionen/finanz-und-kirchendirektion/finanzverwaltung/finanzkennzahlen/downloads>,
       'context': <FileListingBlock at /platform2/politik-und-behorden/direktionen/finanz-und-kirchendirektion/finanzverwaltung/finanzkennzahlen/downloads>,
       'default': <object object at 0x100294bf0>,
       'here': <FileListingBlock at /platform2/politik-und-behorden/direktionen/finanz-und-kirchendirektion/finanzverwaltung/finanzkennzahlen/downloads>,
       'loop': {},
       'nothing': None,
       'options': {},
       'repeat': <Products.PageTemplates.Expressions.SafeMapping object at 0x11bb66e68>,
       'request': <HTTPRequest, URL=http://localhost:8080/platform2/politik-und-behorden/direktionen/finanz-und-kirchendirektion/finanzverwaltung/finanzkennzahlen/downloads/edit.json>,
       'root': <Application at >,
       'template': <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x11b139ad0>,
       'traverse_subpath': [],
       'user': <PropertiedUser 'admin'>,
       'view': <Products.Five.metaclass.FileListingBlockView object at 0x111248590>,
       'views': <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x111248dd0>}
  Module zope.tales.expressions, line 217, in __call__
  Module Products.PageTemplates.Expressions, line 155, in _eval
  Module Products.PageTemplates.Expressions, line 117, in render
  Module ftw.simplelayout.contenttypes.browser.filelistingblock, line 59, in render_table
  Module ftw.table.utils, line 76, in generate
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module zope.pagetemplate.pagetemplate, line 240, in __call__
  Module zope.tal.talinterpreter, line 271, in __call__
  Module zope.tal.talinterpreter, line 343, in interpret
  Module zope.tal.talinterpreter, line 821, in do_loop_tal
  Module zope.tal.talinterpreter, line 343, in interpret
  Module zope.tal.talinterpreter, line 821, in do_loop_tal
  Module zope.tal.talinterpreter, line 343, in interpret
  Module zope.tal.talinterpreter, line 531, in do_optTag_tal
  Module zope.tal.talinterpreter, line 513, in no_tag
  Module zope.tal.talinterpreter, line 343, in interpret
  Module zope.tal.talinterpreter, line 742, in do_insertStructure_tal
  Module Products.PageTemplates.Expressions, line 218, in evaluateStructure
  Module zope.tales.tales, line 696, in evaluate
   - URL: /Users/jone/projects/packages/bl.web/src/ftw.simplelayout/ftw/simplelayout/contenttypes/browser/templates/ftw.table.custom.template.pt
   - Line 22, Column 16
   - Expression: <PythonExpr ( view.get_value(content, col))>
   - Names:
      {'args': (),
       'container': None,
       'context': None,
       'default': <object object at 0x100294bf0>,
       'here': None,
       'loop': {},
       'nothing': None,
       'options': {},
       'repeat': <Products.PageTemplates.Expressions.SafeMapping object at 0x11bb66f18>,
       'request': <HTTPRequest, URL=http://localhost:8080/platform2/politik-und-behorden/direktionen/finanz-und-kirchendirektion/finanzverwaltung/finanzkennzahlen/downloads/edit.json>,
       'root': None,
       'template': <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x11b02f450>,
       'traverse_subpath': [],
       'user': <PropertiedUser 'admin'>,
       'view': <ftw.table.utils.TableGenerator object at 0x110a09b10>,
       'views': <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x111248a10>}
  Module zope.tales.pythonexpr, line 59, in __call__
   - __traceback_info__: ( view.get_value(content, col))
  Module <string>, line 1, in <module>
  Module ftw.table.utils, line 212, in get_value
  Module ftw.table.helper, line 342, in _translate
  Module zope.i18n, line 126, in translate
  Module zope.i18n.translationdomain, line 78, in translate
  Module zope.i18n.translationdomain, line 133, in _recursive_translate
  Module Products.PlacelessTranslationService.lazycatalog, line 32, in queryMessage
  Module gettext, line 403, in ugettext
TypeError: unhashable type: 'Missing.Value'
```