### PR TITLE
Lead-Image: support gallery blocks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Lead-Image: support gallery blocks. [jone]
+
 - Remove "Review State" column from file listing block.
   It is usually not in use, since files has no workflow on simplelayout sites.
   [mathias.leimgruber]

--- a/ftw/simplelayout/contenttypes/browser/leadimage.py
+++ b/ftw/simplelayout/contenttypes/browser/leadimage.py
@@ -1,3 +1,4 @@
+from ftw.simplelayout.contenttypes.contents.interfaces import IGalleryBlock
 from ftw.simplelayout.contenttypes.contents.interfaces import ITextBlock
 from ftw.simplelayout.handlers import unwrap_persistence
 from ftw.simplelayout.interfaces import IPageConfiguration
@@ -39,4 +40,10 @@ class LeadImageView(BrowserView):
                and block.image.data:
                 self.has_image = True
                 self.block = block
-                break
+                return
+
+            if IGalleryBlock.providedBy(block):
+                for image in block.listFolderContents({'portal_type': 'Image'}):
+                    self.has_image = True
+                    self.block = image
+                    return


### PR DESCRIPTION
When looking for the lead image of a SL-container, we now also take
gallery blocks with images into account.