### PR TITLE
Lead-Image: support all slots.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Lead-Image: support all slots. [jone]
+
 - Lead-Image: support gallery blocks. [jone]
 
 - Remove "Review State" column from file listing block.

--- a/ftw/simplelayout/contenttypes/browser/leadimage.py
+++ b/ftw/simplelayout/contenttypes/browser/leadimage.py
@@ -28,9 +28,12 @@ class LeadImageView(BrowserView):
 
     def _get_uids(self):
         page_conf = IPageConfiguration(self.context)
+        # look for blocks in default slot first ...
         state_string = json.dumps(unwrap_persistence(
             page_conf.load().get('default', {})))
-
+        # ... then look in all slots.
+        state_string += json.dumps(unwrap_persistence(
+            page_conf.load()))
         return re.findall(r'\"uid\"\: \"(.+?)\"', state_string)
 
     def _get_image(self):


### PR DESCRIPTION
We need to support having images only in the portlet slot.
This changes looks at first in the default slot, but then looks in all slots for images.