### PR TITLE
hide main scrollbar when overlay is open.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Hide main scrollbar when overlay is opened. [jone]
+
 - Lead-Image: support all slots. [jone]
 
 - Lead-Image: support gallery blocks. [jone]

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -426,3 +426,7 @@ ul[class^="sl-toolbar"] {
     }
   }
 }
+
+.overlay-open {
+  overflow: hidden;
+}


### PR DESCRIPTION
When the overlay is open, we need to disable the main scrollbar, so that scrolling in the overlay does not scroll the main page.

/cc @bierik 