### PR TITLE
Mark different overlay with classes.

### DIFF
--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -30,9 +30,9 @@
     if (!options.canEdit) { return false; }
 
     var deleteOverlay = new global.FormOverlay({cssclass: "overlay-delete"});
-    var editOverlay = new global.FormOverlay();
-    var uploadOverlay = new global.FormOverlay({ disableClose: isUploading });
-    var addOverlay = new global.FormOverlay();
+    var editOverlay = new global.FormOverlay({cssclass: "overlay-edit"});
+    var uploadOverlay = new global.FormOverlay({ cssclass: "overlay-upload", disableClose: isUploading });
+    var addOverlay = new global.FormOverlay({cssclass: "overlay-add"});
     var toolbox;
     var simplelayout;
 


### PR DESCRIPTION
To make it possible to identify the different overlay loaded by simplelayout
mark the overlays with a unique css class.