### PR TITLE
Fix zindex order.

### DIFF
--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -213,7 +213,7 @@ ul[class^="sl-toolbar"] {
   background-color: $color-text;
   visibility: hidden;
   border-radius: $border-radius-primary;
-  z-index: 1;
+  z-index: 4;
   li {
     text-align: center;
     a {


### PR DESCRIPTION
Quick fix for https://github.com/4teamwork/bl.web/issues/84

<img width="536" alt="bildschirmfoto 2016-04-24 um 15 47 35" src="https://cloud.githubusercontent.com/assets/1637820/14767976/27371408-0a34-11e6-924e-90c2cb67db01.png">
<img width="509" alt="bildschirmfoto 2016-04-24 um 15 47 52" src="https://cloud.githubusercontent.com/assets/1637820/14767977/274c3fd6-0a34-11e6-8d28-b595f74b85ff.png">