### PR TITLE
Improve listing of galleryblock + Fix height of empty SimplelayoutPortlet

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- GalleryBlock: Show 4 images in a row for 1 col, 2 in a row for 2 col and 1 a row for 4 col.
+  [mathias.leimgruber]
+
 - Add min-height to SimplelayoutBlock empty columns.
   [mathias.leimgruber]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Add min-height to SimplelayoutBlock empty columns.
+  [mathias.leimgruber]
+
 - Fix mouse pointer position according to openlayers pointer.
   [mathias.leimgruber]
 

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -430,6 +430,15 @@ ul[class^="sl-toolbar"] {
   }
 }
 
+.SimplelayoutPortlet {
+ .sl-column {
+  min-height: 100px;
+    &:empty {
+      border: 1px dashed $color-text;
+    }
+  }
+}
+
 .overlay-open {
   overflow: hidden;
 }

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -419,7 +419,6 @@ ul[class^="sl-toolbar"] {
 }
 
 .galleryblockImageWrapper {
-  @include floatgrid(4, $by-index: false);
   margin-bottom: $margin-vertical;
   > a {
     display: block;
@@ -428,6 +427,20 @@ ul[class^="sl-toolbar"] {
       margin: 0;
     }
   }
+}
+
+@for $x from 1 through $columns {
+  .sl-col-#{$x} .galleryblockImageWrapper {
+    @if $x <= 4 {
+      @include floatgrid(4 / $x, $by-index: false);
+    } @else {
+      @include floatgrid(1, $by-index: false);
+    }
+  }
+}
+
+.SimplelayoutPortlet .galleryblockImageWrapper {
+  @include floatgrid(1, $by-index: false);
 }
 
 .SimplelayoutPortlet {

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -435,6 +435,7 @@ ul[class^="sl-toolbar"] {
   min-height: 100px;
     &:empty {
       border: 1px dashed $color-text;
+      margin-bottom: $margin-vertical;
     }
   }
 }


### PR DESCRIPTION
Fix height of empty SLPortlet - this makes it easier to drop blocks into it. 
<img width="825" alt="screen shot 2016-04-27 at 10 25 22" src="https://cloud.githubusercontent.com/assets/437933/14852527/238c7596-0c87-11e6-85f4-9cd755fc295e.png">

**Portlet and 4 Col (1 img per row)**
<img width="565" alt="screen shot 2016-04-27 at 10 29 07" src="https://cloud.githubusercontent.com/assets/437933/14852546/4971b0be-0c87-11e6-8715-4545b2735a73.png">

**2 Col (2 img per row)**
<img width="790" alt="screen shot 2016-04-27 at 10 29 00" src="https://cloud.githubusercontent.com/assets/437933/14852544/496e3722-0c87-11e6-9863-2114e67afe93.png">

**1 Col (4 img per row)**
<img width="799" alt="screen shot 2016-04-27 at 10 28 52" src="https://cloud.githubusercontent.com/assets/437933/14852545/496fa706-0c87-11e6-85c8-15ad2487e4cb.png">

---

Closes #326 