### PR TITLE
Add image caption for textblock

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - Fix mouse pointer position according to openlayers pointer.
   [mathias.leimgruber]
 
+- Add image caption field to textblock.
+  [mathias.leimgruber]
+
 - Hide main scrollbar when overlay is opened. [jone]
 
 - Lead-Image: support all slots. [jone]

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -47,6 +47,9 @@
     &.right {
       margin-left: $margin-paragraph-vertical;
     }
+    .image-caption {
+      text-align: center;
+    }
   }
 }
 

--- a/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
@@ -20,6 +20,8 @@
                            class image/link_css_classes">
             <img tal:replace="structure image/image_tag" />
         </a>
+        <div class="hiddenStructure" i18n:translate="hidden_label_image_caption">Image caption:</div>
+        <div class="image-caption" tal:content="context/image_caption" />
     </div>
   </tal:image>
   <div tal:replace="structure here/text/output | nothing" />

--- a/ftw/simplelayout/contenttypes/contents/textblock.py
+++ b/ftw/simplelayout/contenttypes/contents/textblock.py
@@ -21,6 +21,12 @@ class ITextBlockSchema(form.Schema):
     """TextBlock for simplelayout
     """
 
+    form.fieldset('image',
+                  label=_(u'Image'),
+                  fields=['image', 'image_alt_text', 'image_caption',
+                          'open_image_in_overlay']
+                  )
+
     title = schema.TextLine(
         title=_(u'label_title', default=u'Title'),
         required=False)

--- a/ftw/simplelayout/contenttypes/contents/textblock.py
+++ b/ftw/simplelayout/contenttypes/contents/textblock.py
@@ -45,6 +45,10 @@ class ITextBlockSchema(form.Schema):
         title=_(u'label_image_alt_text', default=u'Image alternative text'),
         required=False)
 
+    image_caption = schema.TextLine(
+        title=_(u'label_image_caption', default=u'Image caption'),
+        required=False)
+
     open_image_in_overlay = schema.Bool(
         title=_(u'label_open_image_in_overlay',
                 default=u'Open image in overlay'

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-08 08:17+0000\n"
+"POT-Creation-Date: 2016-04-28 07:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,7 +36,7 @@ msgid "GalleryBlock"
 msgstr "Bildergalerie"
 
 #. Default: "ID"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:75
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:70
 msgid "ID"
 msgstr "ID"
 
@@ -131,7 +131,7 @@ msgstr "Der Video-Block zeigt Videos von YouTube oder Vimeo an."
 
 #: ./ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt:8
 #: ./ftw/simplelayout/contenttypes/browser/templates/listingblock.pt:10
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:26
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:28
 msgid "This block is empty."
 msgstr "Dieser Block hat keinen Inhalt."
 
@@ -198,7 +198,7 @@ msgid "desc_sl_config_control_panel"
 msgstr "Simplelayout Standard-Konfiguration hinzufügen, siehe Dokumentation: https://github.com/4teamwork/ftw.simplelayout#usage"
 
 #. Default: "This will visually hide the block. This is not a security feature, the block and its content can still be accessed."
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:162
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:157
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:29
 msgid "description_is_hidden"
 msgstr "Dies versteckt den Block rein visuell. Dies ist kein Sicherheits-Feature, der Block und sein Inhalt bleibt immer noch aufrufbar."
@@ -229,6 +229,11 @@ msgstr ""
 msgid "help_drag_hint"
 msgstr "Bitte den Inhalt per Drag & Drop hinzufügen."
 
+#. Default: "Image caption:"
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:23
+msgid "hidden_label_image_caption"
+msgstr "Bild Legende:"
+
 #. Default: "${title}, enlarged picture."
 #: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:32
 #: ./ftw/simplelayout/contenttypes/browser/textblock.py:83
@@ -241,12 +246,12 @@ msgid "label:delete_block"
 msgstr "Block entfernen"
 
 #. Default: "sort_index"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:108
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:103
 msgid "label_%ssort_index"
 msgstr "Sortierung"
 
 #. Default: "Ascending"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:123
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:118
 msgid "label_ascending"
 msgstr "Aufsteigend"
 
@@ -261,7 +266,7 @@ msgid "label_column_postfix"
 msgstr " Spalte(n)"
 
 #. Default: "Columns"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:143
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:138
 msgid "label_columns"
 msgstr "Spalten"
 
@@ -271,7 +276,7 @@ msgid "label_delete_layout"
 msgstr "Zeile löschen"
 
 #. Default: "Descending"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:125
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:120
 msgid "label_descending"
 msgstr "Absteigend"
 
@@ -289,27 +294,27 @@ msgid "label_external_link"
 msgstr "Externe URL"
 
 #. Default: "Float image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:91
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:95
 msgid "label_float_image_left"
 msgstr "Bild links ausrichten"
 
 #. Default: "Float image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:130
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:134
 msgid "label_float_image_right"
 msgstr "Bild rechts ausrichten"
 
 #. Default: "Float large image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:100
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:104
 msgid "label_float_large_image_left"
 msgstr "Grosses Bild links ausrichten"
 
 #. Default: "Float large image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:120
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:124
 msgid "label_float_large_image_right"
 msgstr "Grosses Bild rechts ausrichten"
 
 #. Default: "Go to folder contents for managing files"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:192
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:187
 msgid "label_folder_contents_files"
 msgstr "Dateien über Inhalte verwalten."
 
@@ -331,8 +336,13 @@ msgstr "Bild"
 msgid "label_image_alt_text"
 msgstr "Alternativer Text des Bildes"
 
+#. Default: "Image caption"
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:49
+msgid "label_image_caption"
+msgstr "Bildlegende"
+
 #. Default: "Image without floating"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:110
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:114
 msgid "label_image_without_floating"
 msgstr "Bild ohne Ausrichtung"
 
@@ -342,7 +352,7 @@ msgid "label_internal_link"
 msgstr "Interne Referenz"
 
 #. Default: "Hide the block"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:161
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:156
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:28
 msgid "label_is_hidden"
 msgstr "Block verstecken"
@@ -361,7 +371,7 @@ msgid "label_move_layout"
 msgstr "Zeile verschieben"
 
 #. Default: "Open image in overlay (only if there is no teaser url)"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:49
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:53
 msgid "label_open_image_in_overlay"
 msgstr "Bild in Overlay öffnen (nur wenn keine Teaser-URL hinterlegt ist)"
 
@@ -369,24 +379,24 @@ msgid "label_portal_type"
 msgstr "Typ"
 
 #. Default: "Position in Folder"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:113
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:108
 msgid "label_position_in_folder"
 msgstr "Ordnerreihenfolge"
 
 #. Default: "Show title"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:138
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:133
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:29
 msgid "label_show_title"
 msgstr "Titel anzeigen?"
 
 #. Default: "Sort by"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:149
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:144
 msgid "label_sort_on"
 msgstr "Sortieren nach"
 
 #. Default: "Sort order"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:155
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:150
 msgid "label_sort_order"
 msgstr "Sortierreihenfolge"
 
@@ -399,14 +409,14 @@ msgid "label_text"
 msgstr "Text"
 
 #. Default: "Title"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:134
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:129
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:19
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:25
 msgid "label_title"
 msgstr "Titel"
 
 #. Default: "Upload"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:185
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:180
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:52
 msgid "label_upload"
 msgstr "Datei hochladen"
@@ -415,11 +425,6 @@ msgstr "Datei hochladen"
 #: ./ftw/simplelayout/contenttypes/contents/videoblock.py:33
 msgid "label_video_url"
 msgstr "Video-URL"
-
-#. Default: "Review State"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:70
-msgid "review_state"
-msgstr "Status"
 
 #. Default: "These internal links will be broken"
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:37

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-28 07:30+0000\n"
+"POT-Creation-Date: 2016-04-28 07:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,6 +39,10 @@ msgstr "Bildergalerie"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:70
 msgid "ID"
 msgstr "ID"
+
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:25
+msgid "Image"
+msgstr "Bild"
 
 #: ./ftw/simplelayout/contenttypes/behaviors.py:40
 msgid "It's not possible to have an internal_link and an external_link together"
@@ -294,22 +298,22 @@ msgid "label_external_link"
 msgstr "Externe URL"
 
 #. Default: "Float image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:95
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:101
 msgid "label_float_image_left"
 msgstr "Bild links ausrichten"
 
 #. Default: "Float image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:134
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:140
 msgid "label_float_image_right"
 msgstr "Bild rechts ausrichten"
 
 #. Default: "Float large image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:104
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:110
 msgid "label_float_large_image_left"
 msgstr "Grosses Bild links ausrichten"
 
 #. Default: "Float large image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:124
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:130
 msgid "label_float_large_image_right"
 msgstr "Grosses Bild rechts ausrichten"
 
@@ -327,22 +331,22 @@ msgid "label_id"
 msgstr "ID"
 
 #. Default: "Image"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:41
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:47
 msgid "label_image"
 msgstr "Bild"
 
 #. Default: "Image alternative text"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:45
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:51
 msgid "label_image_alt_text"
 msgstr "Alternativer Text des Bildes"
 
 #. Default: "Image caption"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:49
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:55
 msgid "label_image_caption"
 msgstr "Bildlegende"
 
 #. Default: "Image without floating"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:114
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:120
 msgid "label_image_without_floating"
 msgstr "Bild ohne Ausrichtung"
 
@@ -371,7 +375,7 @@ msgid "label_move_layout"
 msgstr "Zeile verschieben"
 
 #. Default: "Open image in overlay (only if there is no teaser url)"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:53
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:59
 msgid "label_open_image_in_overlay"
 msgstr "Bild in Overlay öffnen (nur wenn keine Teaser-URL hinterlegt ist)"
 
@@ -386,7 +390,7 @@ msgstr "Ordnerreihenfolge"
 #. Default: "Show title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:133
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:29
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:35
 msgid "label_show_title"
 msgstr "Titel anzeigen?"
 
@@ -404,14 +408,14 @@ msgid "label_sortable_title"
 msgstr "Titel"
 
 #. Default: "Text"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:35
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:41
 msgid "label_text"
 msgstr "Text"
 
 #. Default: "Title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:129
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:19
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:25
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:31
 msgid "label_title"
 msgstr "Titel"
 

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-08 08:17+0000\n"
+"POT-Creation-Date: 2016-04-28 07:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,7 +39,7 @@ msgid "GalleryBlock"
 msgstr ""
 
 #. Default: "ID"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:75
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:70
 msgid "ID"
 msgstr ""
 
@@ -134,7 +134,7 @@ msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt:8
 #: ./ftw/simplelayout/contenttypes/browser/templates/listingblock.pt:10
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:26
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:28
 msgid "This block is empty."
 msgstr ""
 
@@ -201,7 +201,7 @@ msgid "desc_sl_config_control_panel"
 msgstr ""
 
 #. Default: "This will visually hide the block. This is not a security feature, the block and its content can still be accessed."
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:162
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:157
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:29
 msgid "description_is_hidden"
 msgstr ""
@@ -232,6 +232,11 @@ msgstr ""
 msgid "help_drag_hint"
 msgstr ""
 
+#. Default: "Image caption:"
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:23
+msgid "hidden_label_image_caption"
+msgstr ""
+
 #. Default: "${title}, enlarged picture."
 #: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:32
 #: ./ftw/simplelayout/contenttypes/browser/textblock.py:83
@@ -244,12 +249,12 @@ msgid "label:delete_block"
 msgstr ""
 
 #. Default: "sort_index"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:108
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:103
 msgid "label_%ssort_index"
 msgstr ""
 
 #. Default: "Ascending"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:123
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:118
 msgid "label_ascending"
 msgstr ""
 
@@ -264,7 +269,7 @@ msgid "label_column_postfix"
 msgstr ""
 
 #. Default: "Columns"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:143
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:138
 msgid "label_columns"
 msgstr ""
 
@@ -274,7 +279,7 @@ msgid "label_delete_layout"
 msgstr ""
 
 #. Default: "Descending"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:125
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:120
 msgid "label_descending"
 msgstr ""
 
@@ -292,27 +297,27 @@ msgid "label_external_link"
 msgstr ""
 
 #. Default: "Float image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:91
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:95
 msgid "label_float_image_left"
 msgstr ""
 
 #. Default: "Float image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:130
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:134
 msgid "label_float_image_right"
 msgstr ""
 
 #. Default: "Float large image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:100
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:104
 msgid "label_float_large_image_left"
 msgstr ""
 
 #. Default: "Float large image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:120
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:124
 msgid "label_float_large_image_right"
 msgstr ""
 
 #. Default: "Go to folder contents for managing files"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:192
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:187
 msgid "label_folder_contents_files"
 msgstr ""
 
@@ -334,8 +339,13 @@ msgstr ""
 msgid "label_image_alt_text"
 msgstr ""
 
+#. Default: "Image caption"
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:49
+msgid "label_image_caption"
+msgstr ""
+
 #. Default: "Image without floating"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:110
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:114
 msgid "label_image_without_floating"
 msgstr ""
 
@@ -345,7 +355,7 @@ msgid "label_internal_link"
 msgstr ""
 
 #. Default: "Hide the block"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:161
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:156
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:28
 msgid "label_is_hidden"
 msgstr ""
@@ -364,7 +374,7 @@ msgid "label_move_layout"
 msgstr ""
 
 #. Default: "Open image in overlay (only if there is no teaser url)"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:49
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:53
 msgid "label_open_image_in_overlay"
 msgstr ""
 
@@ -372,24 +382,24 @@ msgid "label_portal_type"
 msgstr ""
 
 #. Default: "Position in Folder"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:113
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:108
 msgid "label_position_in_folder"
 msgstr ""
 
 #. Default: "Show title"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:138
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:133
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:29
 msgid "label_show_title"
 msgstr ""
 
 #. Default: "Sort by"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:149
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:144
 msgid "label_sort_on"
 msgstr ""
 
 #. Default: "Sort order"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:155
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:150
 msgid "label_sort_order"
 msgstr ""
 
@@ -402,14 +412,14 @@ msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:134
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:129
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:19
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:25
 msgid "label_title"
 msgstr ""
 
 #. Default: "Upload"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:185
+#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:180
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:52
 msgid "label_upload"
 msgstr ""
@@ -417,11 +427,6 @@ msgstr ""
 #. Default: "Youtube, or Vimeo URL"
 #: ./ftw/simplelayout/contenttypes/contents/videoblock.py:33
 msgid "label_video_url"
-msgstr ""
-
-#. Default: "Review State"
-#: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:70
-msgid "review_state"
 msgstr ""
 
 #. Default: "These internal links will be broken"

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-04-28 07:30+0000\n"
+"POT-Creation-Date: 2016-04-28 07:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -41,6 +41,10 @@ msgstr ""
 #. Default: "ID"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:70
 msgid "ID"
+msgstr ""
+
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:25
+msgid "Image"
 msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/behaviors.py:40
@@ -297,22 +301,22 @@ msgid "label_external_link"
 msgstr ""
 
 #. Default: "Float image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:95
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:101
 msgid "label_float_image_left"
 msgstr ""
 
 #. Default: "Float image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:134
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:140
 msgid "label_float_image_right"
 msgstr ""
 
 #. Default: "Float large image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:104
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:110
 msgid "label_float_large_image_left"
 msgstr ""
 
 #. Default: "Float large image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:124
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:130
 msgid "label_float_large_image_right"
 msgstr ""
 
@@ -330,22 +334,22 @@ msgid "label_id"
 msgstr ""
 
 #. Default: "Image"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:41
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:47
 msgid "label_image"
 msgstr ""
 
 #. Default: "Image alternative text"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:45
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:51
 msgid "label_image_alt_text"
 msgstr ""
 
 #. Default: "Image caption"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:49
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:55
 msgid "label_image_caption"
 msgstr ""
 
 #. Default: "Image without floating"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:114
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:120
 msgid "label_image_without_floating"
 msgstr ""
 
@@ -374,7 +378,7 @@ msgid "label_move_layout"
 msgstr ""
 
 #. Default: "Open image in overlay (only if there is no teaser url)"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:53
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:59
 msgid "label_open_image_in_overlay"
 msgstr ""
 
@@ -389,7 +393,7 @@ msgstr ""
 #. Default: "Show title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:133
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:29
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:35
 msgid "label_show_title"
 msgstr ""
 
@@ -407,14 +411,14 @@ msgid "label_sortable_title"
 msgstr ""
 
 #. Default: "Text"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:35
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:41
 msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:129
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:19
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:25
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:31
 msgid "label_title"
 msgstr ""
 


### PR DESCRIPTION
Also move image related fields into a image fieldset

<img width="629" alt="screen shot 2016-04-28 at 09 49 25" src="https://cloud.githubusercontent.com/assets/437933/14878912/8d8d513c-0d26-11e6-9112-6fd2b3918d7e.png">
<img width="529" alt="screen shot 2016-04-28 at 09 50 00" src="https://cloud.githubusercontent.com/assets/437933/14878923/99bda4d4-0d26-11e6-98d6-ee9345c82dff.png">
