### PR TITLE
Remove bottom margin for TextBlocks containing only a title

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Do not show empty block warning on textblock if there is only a title.
+  [mathias.leimgruber]
+
 - GalleryBlock: Show 4 images in a row for 1 col, 2 in a row for 2 col and 1 a row for 4 col.
   [mathias.leimgruber]
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Remove block bottom margin from textblocks containing only a title.
+  [mathias.leimgruber]
+
 - Do not show empty block warning on textblock if there is only a title.
   [mathias.leimgruber]
 

--- a/ftw/simplelayout/browser/provider.py
+++ b/ftw/simplelayout/browser/provider.py
@@ -100,6 +100,8 @@ class BaseSimplelayoutExpression(object):
         if block_is_hidden:
             css_classes.append('hidden')
 
+        css_classes.extend(getattr(obj, 'additional_css', []))
+
         block_dict['is_hidden'] = block_is_hidden
         block_dict['obj_html'] = self._render_block_html(obj)
         block_dict['type'] = block_type

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -99,6 +99,9 @@
   position: relative;
   float: left;
   margin-bottom: $margin-vertical;
+  &.titleOnly {
+    margin-bottom: 0;
+  }
   &.ui-sortable-helper {
     opacity: .8;
   }

--- a/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
@@ -25,7 +25,7 @@
     </div>
   </tal:image>
   <div tal:replace="structure here/text/output | nothing" />
-  <p tal:condition="python: view.can_add and not (here.image or here.text)"
+  <p tal:condition="python: view.can_add and not (here.image or here.text or here.title)"
      i18n:translate="">This block is empty.</p>
 
 </html>

--- a/ftw/simplelayout/contenttypes/contents/textblock.py
+++ b/ftw/simplelayout/contenttypes/contents/textblock.py
@@ -69,6 +69,13 @@ alsoProvides(ITextBlockSchema, IFormFieldProvider)
 class TextBlock(Item):
     implements(ITextBlock)
 
+    @property
+    def additional_css(self):
+        if self.title and not (self.image or self.text):
+            return ['titleOnly']
+        else:
+            return []
+
 
 class TextBlockModifier(object):
 

--- a/ftw/simplelayout/tests/test_textblock_view.py
+++ b/ftw/simplelayout/tests/test_textblock_view.py
@@ -244,3 +244,13 @@ class TestTextBlockRendering(TestCase):
             browser.css('a.colorboxLink').first.attrib['title'].endswith(
                 'enlarged picture.'),
             'Expect "enlarged picture." hint in alt text of img.')
+
+    @browsing
+    def test_title_only_css_class(self, browser):
+        create(Builder('sl textblock')
+               .within(self.page)
+               .titled('TextBlock title'))
+
+        browser.login().visit(self.page)
+        self.assertTrue(
+            browser.css('.sl-block.titleOnly'), 'Expext title only class.')


### PR DESCRIPTION
bases on #331 

This way it's possible to place a title only block without additional spacing.

<img width="870" alt="screen shot 2016-05-11 at 16 50 00" src="https://cloud.githubusercontent.com/assets/437933/15185430/6a580c5c-1799-11e6-8a7e-7f05d9f9072a.png">


Also show the empty block warning, only if the block is really empty.