### PR TITLE
Update z3c.form to 3.2.9 to fix IE11 bug when adding a filelisting-block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Update z3c.form to 2.9.3.
+  Fixes error when adding a filelisting-block in IE11.
+  [Kevin Bieri]
+
 - Remove block bottom margin from textblocks containing only a title.
   [mathias.leimgruber]
 

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(name='ftw.simplelayout',
           'zope.lifecycleevent',
           'zope.publisher',
           'Zope2',
+          'z3c.form>=3.2.9',
           'Plone',
           ],
 


### PR DESCRIPTION
Adding a filelisting-block failed on IE11.
See https://github.com/zopefoundation/z3c.form/pull/37.