### PR TITLE
Implement statekeeper for tracking DOM changes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Implement statekeeter to track DOM changes.
+  [Kevin Bieri]
+
 - Update z3c.form to 2.9.3.
   Fixes error when adding a filelisting-block in IE11.
   [Kevin Bieri]

--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -10,10 +10,10 @@
       if(!queryString) {
         return {};
       }
-      var params = {}
-      var queries
-      var temp
-      var i
+      var params = {};
+      var queries;
+      var temp;
+      var i;
       var l;
       queries = queryString.split("&");
       for (i = 0, l = queries.length; i < l; i++) {
@@ -21,7 +21,7 @@
         params[temp[0]] = temp[1];
       }
       return params;
-    };
+    }
 
     function parseURL(url) {
       url = url || document.URL;
@@ -30,7 +30,7 @@
       return parser;
     }
 
-    function restore() { counter = parseInt(global.localStorage.getItem("sl-state-counter")) || 0; }
+    function restore() { counter = parseInt(global.localStorage.getItem("sl-state-counter"), 10) || 0; }
 
     function createURL() {
       var url = parseURL();


### PR DESCRIPTION
Closes https://github.com/4teamwork/bl.web/issues/162

DOM modifications from the simplelayout are not tracked
from the browser as a new page. So we have to trigger
a manual history change.

Tested with 
`http://localhost`,
`http://localhost?key=value`,
`http://localhost?key=value&anohterkey=antohervalue`,
`http://localhost#hash`,
`http://localhost?key=value#hash`,
`http://localhost?key=value&anohterkey=antohervalue#hash`