### PR TITLE
Prevent iframe from stopping event bubbling in IE.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BugFix for IE11 VideoBlock: Prevent iframe from stopping event bubbling in IE
+  [Kevin Bieri]
 
 
 1.4.1 (2016-05-24)

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -91,6 +91,21 @@
   }
 }
 
+// Videoblock
+.sl-can-edit .ftw-simplelayout-videoblock {
+  .sl-block-content {
+    @include ie-only() {
+      cursor: not-allowed;
+    }
+  }
+
+  iframe {
+    @include ie-only() {
+      pointer-events: none;
+    }
+  }
+}
+
 .sl-block {
   @include clearfix();
   width: 100%;


### PR DESCRIPTION
Closes https://github.com/4teamwork/bl.web/issues/214

In IE it is not possible to track events on wrapping elements
containing an iframe.