### PR TITLE
Implement request tracker.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.4.3 (unreleased)
 ------------------
 
+- Implement request tracker.
+  [Kevin Bieri]
+
 - Block Views: Check for extisting viewname before setting the view_name value.
   [mathias.leimgruber]
 

--- a/ftw/simplelayout/browser/resources/RequestTracker.js
+++ b/ftw/simplelayout/browser/resources/RequestTracker.js
@@ -1,0 +1,116 @@
+(function(global, $) {
+
+  "use strict";
+
+  var URLWhiteList = [
+    "sl-ajax-reload-block-view",
+    "sl-toolbox-view",
+    "sl-ajax-delete-blocks-view",
+    "add_block",
+    "sl-ajax-edit-block-view",
+    "sl-ajax-upload-block-view",
+    "edit.json",
+    "tiny_mce_gzip.js"
+  ];
+
+  var URLBlackList = [
+    "@@z3cform_validate_field"
+  ];
+
+  function getParameterByName(name, url) {
+    name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
+    var regex = new RegExp("[\\?&]" + name + "=([^&#]*)");
+    var results = regex.exec(url);
+    return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+  }
+
+  function Request(url, callback, options) {
+
+    options = $.extend({ threshold: 300 }, options);
+
+    var threshold = getParameterByName("threshold", url) || options.threshold;
+    var timer;
+
+    function isThrottled() {
+      var spinnerFlag = getParameterByName("spinner", url);
+      return spinnerFlag === "" && spinnerFlag !== "false";
+    }
+
+    function throttle() {
+      if(isThrottled()) {
+        timer = global.setTimeout(callback, threshold);
+      }
+    }
+
+    function cancel() { global.clearTimeout(timer); }
+
+    throttle();
+
+    return Object.freeze({
+      throttle: throttle,
+      cancel: cancel
+    });
+
+  }
+
+  function RequestTracker() {
+
+    var markerClass = "ajax-loading";
+    var $document = $(document);
+    var root = $(":root");
+
+    var requests = {};
+
+    function checkURL(url) {
+      var isWhiteListed = !!$.grep(URLWhiteList, function(whiteListEntry) {
+        return url.indexOf(whiteListEntry) >= 0;
+      }).length;
+
+      var isBlackListed = !!$.grep(URLBlackList, function(blackListEntry) {
+        return url.indexOf(blackListEntry) >= 0;
+      }).length;
+
+      return isWhiteListed && !isBlackListed;
+    }
+
+    function mark() { root.addClass(markerClass); }
+
+    function unmark() {
+      if(!Object.keys(requests).length) {
+        root.removeClass(markerClass);
+      }
+    }
+
+    function track(url) {
+      if(checkURL(url)) {
+        requests[url] = Request(url, mark);
+      }
+    }
+
+    function untrack(url) {
+      if(requests[url]) {
+        requests[url].cancel();
+        delete requests[url];
+        unmark();
+      }
+    }
+
+    /*
+      Disable kss spinner. In order for this to work, this file must be evaluated after kss-bbb.js.
+      As you can see in the lib profile's jsregistry.xml.
+    */
+    $document.off("ajaxStart");
+
+    $document.on("ajaxSend", function(event, jqxhr, params) { track(params.url); });
+    $document.on("ajaxComplete", function(event, jqxhr, params) { untrack(params.url); });
+
+    return Object.freeze({
+      track: track,
+      untrack: untrack
+    });
+
+  }
+
+  RequestTracker();
+
+})(window, window.jQuery);

--- a/ftw/simplelayout/profiles/lib/jsregistry.xml
+++ b/ftw/simplelayout/profiles/lib/jsregistry.xml
@@ -36,4 +36,11 @@
         compression="none"
         />
 
+    <javascript
+        id="++resource++ftw.simplelayout.resources/RequestTracker.js"
+        enabled="True"
+        authenticated="True"
+        insert-after="kss-bbb.js"
+        />
+
 </object>

--- a/ftw/simplelayout/upgrades/20160525161113_register_request_tracker_javascript/jsregistry.xml
+++ b/ftw/simplelayout/upgrades/20160525161113_register_request_tracker_javascript/jsregistry.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+
+    <javascript
+        id="++resource++ftw.simplelayout.resources/RequestTracker.js"
+        enabled="True"
+        authenticated="True"
+        insert-after="kss-bbb.js"
+        />
+
+</object>

--- a/ftw/simplelayout/upgrades/20160525161113_register_request_tracker_javascript/upgrade.py
+++ b/ftw/simplelayout/upgrades/20160525161113_register_request_tracker_javascript/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RegisterRequestTrackerJavascript(UpgradeStep):
+    """Register RequestTracker javascript.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The request tracker tracks URLs which are not banned
through a white and blacklist system. When a request lasts
longer than a specific threshold (300ms by default) the root element
will be extended with a marker class (ajax-loading)