### PR TITLE
Add sort options for image galleries

### DIFF
--- a/development.cfg
+++ b/development.cfg
@@ -4,4 +4,6 @@ extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg
 
 [instance]
-eggs += ftw.simplelayout [contenttypes, mapblock]
+eggs +=
+    ftw.simplelayout [contenttypes, mapblock]
+    plonetheme.blueberry

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -111,6 +111,9 @@ Changelog
   This fixes a issue, when it was no longer possible to re-add a layout after deleting the last one.
   [mathias.leimgruber]
 
+- Add sort-options to image gallery block.
+  [raphael-s]
+
 
 1.5.2 (2016-05-26)
 ------------------

--- a/ftw/simplelayout/contenttypes/browser/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/browser/galleryblock.py
@@ -16,12 +16,11 @@ class GalleryBlockView(BaseBlock):
         imgBrains = self.context.portal_catalog.searchResults(
             portal_type="Image",
             sort_on=self.context.sort_on,
-            sort_order=self.context.sort_order)
+            sort_order=self.context.sort_order,
+            path='/'.join(self.context.getPhysicalPath()))
         images = []
         for img in imgBrains:
-            imgObj = img.getObject()
-            if imgObj.getParentNode() == self.context:
-                images.append(imgObj)
+            images.append(img.getObject())
         return images
 
     def get_box_boundaries(self):

--- a/ftw/simplelayout/contenttypes/browser/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/browser/galleryblock.py
@@ -13,8 +13,16 @@ class GalleryBlockView(BaseBlock):
     template = ViewPageTemplateFile('templates/galleryblock.pt')
 
     def get_images(self):
-        return self.context.listFolderContents(
-            contentFilter=dict(portal_type=['Image']))
+        imgBrains = self.context.portal_catalog.searchResults(
+            portal_type="Image",
+            sort_on=self.context.sort_on,
+            sort_order=self.context.sort_order)
+        images = []
+        for img in imgBrains:
+            imgObj = img.getObject()
+            if imgObj.getParentNode() == self.context:
+                images.append(imgObj)
+        return images
 
     def get_box_boundaries(self):
         return getAllowedSizes().get('simplelayout_galleryblock')

--- a/ftw/simplelayout/contenttypes/contents/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/contents/galleryblock.py
@@ -8,7 +8,36 @@ from plone.directives import form
 from zope import schema
 from zope.i18n import translate
 from zope.interface import alsoProvides
+from zope.interface import directlyProvides
 from zope.interface import implements
+from zope.schema.interfaces import IContextSourceBinder
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+def sort_index_vocabulary(context):
+    terms = []
+    terms.append(SimpleVocabulary.createTerm(
+        'sortable_title',
+        'sortable_title',
+        _(u'label_sort_by_title',
+            default=u'Title')))
+    terms.append(SimpleVocabulary.createTerm(
+        'modified',
+        'modified',
+        _(u'column_modified',
+            default=u'Latest changes')))
+
+    return SimpleVocabulary(terms)
+
+directlyProvides(sort_index_vocabulary, IContextSourceBinder)
+
+sort_order_vocabulary = SimpleVocabulary([
+    SimpleTerm(value='ascending',
+               title=_(u'label_ascending', default=u'Ascending')),
+    SimpleTerm(value='descending',
+               title=_(u'label_descending', default=u'Descending'))
+])
 
 
 class IGalleryBlockSchema(form.Schema):
@@ -23,6 +52,18 @@ class IGalleryBlockSchema(form.Schema):
         title=_(u'label_show_title', default=u'Show title'),
         default=True,
         required=False)
+
+    sort_on = schema.Choice(
+        title=_(u'label_sort_on', default=u'Sort by'),
+        required=True,
+        default="sortable_title",
+        source=sort_index_vocabulary)
+
+    sort_order = schema.Choice(
+        title=_(u'label_sort_order', default=u'Sort order'),
+        required=True,
+        default="ascending",
+        vocabulary=sort_order_vocabulary)
 
     is_hidden = schema.Bool(
         title=_(u'label_is_hidden', default=u'Hide the block'),

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -35,6 +35,36 @@ class TestGalleryBlock(TestCase):
             "Available scales: {0}".format(allowed_sizes))
 
     @browsing
+    def test_get_images_only_returns_images_of_current_context(self, browser):
+        gallery1 = create(Builder('sl galleryblock')
+                          .titled('Galleryblock 1')
+                          .having(show_title=True)
+                          .within(self.page))
+
+        create(Builder('image')
+               .titled('gallery1_img')
+               .with_dummy_content()
+               .within(gallery1))
+
+        gallery2 = create(Builder('sl galleryblock')
+                          .titled('Galleryblock 2')
+                          .having(show_title=True)
+                          .within(self.page))
+
+        create(Builder('image')
+               .titled('gallery2_img')
+               .with_dummy_content()
+               .within(gallery2))
+
+        browser.login().visit(self.page)
+
+        css_items = browser.css(
+            'a.colorboxLink[rel="colorbox-galleryblock-1"] img')
+        nodes = [node.get('alt').split(',')[0] for node in css_items]
+
+        self.assertEqual(nodes, ['gallery1_img'])
+
+    @browsing
     def test_rendering(self, browser):
         create(Builder('sl galleryblock')
                .titled('My galleryblock')
@@ -341,3 +371,5 @@ class TestGalleryBlock(TestCase):
             img_title_list.append(img.get('alt').split(',')[0])
 
         self.assertEqual(img_title_list, ['b_img', 'c_img', 'a_img'])
+
+

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -1,3 +1,4 @@
+from DateTime import DateTime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
@@ -177,16 +178,17 @@ class TestGalleryBlock(TestCase):
         )
 
     @browsing
-    def test_hidden_galleryblock_not_visible_without_edit_permission(self, browser):
+    def test_hidden_galleryblock_not_visible_without_edit_permission(self,
+                                                                     browser):
         """
         This test makes sure that users without edit permission, e.g. the
         anonymous user, do not see the hidden block.
         """
-        galleryblock = create(Builder('sl galleryblock')
-                              .titled('My galleryblock')
-                              .having(show_title=True)
-                              .having(is_hidden=True)
-                              .within(self.page))
+        create(Builder('sl galleryblock')
+               .titled('My galleryblock')
+               .having(show_title=True)
+               .having(is_hidden=True)
+               .within(self.page))
 
         # Make sure an anonymous user cannot see the block.
         browser.logout().visit(self.page)
@@ -201,3 +203,141 @@ class TestGalleryBlock(TestCase):
             ['My galleryblock'],
             browser.css('.ftw-simplelayout-galleryblock h2').text
         )
+
+    @browsing
+    def test_sort_by_title_ascending(self, browser):
+        gallery = create(Builder('sl galleryblock')
+                         .titled('My galleryblock')
+                         .having(sort_on='sortable_title')
+                         .having(sort_order='ascending')
+                         .within(self.page))
+
+        create(Builder('image')
+               .titled('a_img')
+               .with_dummy_content()
+               .within(gallery))
+
+        create(Builder('image')
+               .titled('b_img')
+               .with_dummy_content()
+               .within(gallery))
+
+        create(Builder('image')
+               .titled('c_img')
+               .with_dummy_content()
+               .within(gallery))
+
+        browser.login().visit(self.page)
+
+        img_list = browser.css('.colorboxLink img')
+        img_title_list = []
+
+        for img in img_list:
+            img_title_list.append(img.get('alt').split(',')[0])
+
+        self.assertEqual(img_title_list, ['a_img', 'b_img', 'c_img'])
+
+    @browsing
+    def test_sort_by_title_descending(self, browser):
+        gallery = create(Builder('sl galleryblock')
+                         .titled('My galleryblock')
+                         .having(sort_on='sortable_title')
+                         .having(sort_order='descending')
+                         .within(self.page))
+
+        create(Builder('image')
+               .titled('a_img')
+               .with_dummy_content()
+               .within(gallery))
+
+        create(Builder('image')
+               .titled('b_img')
+               .with_dummy_content()
+               .within(gallery))
+
+        create(Builder('image')
+               .titled('c_img')
+               .with_dummy_content()
+               .within(gallery))
+
+        browser.login().visit(self.page)
+
+        img_list = browser.css('.colorboxLink img')
+        img_title_list = []
+
+        for img in img_list:
+            img_title_list.append(img.get('alt').split(',')[0])
+
+        self.assertEqual(img_title_list, ['c_img', 'b_img', 'a_img'])
+
+    @browsing
+    def test_sort_by_modified_ascending(self, browser):
+        gallery = create(Builder('sl galleryblock')
+                         .titled('My galleryblock')
+                         .having(sort_on='modified')
+                         .having(sort_order='ascending')
+                         .within(self.page))
+
+        create(Builder('image')
+               .titled('a_img')
+               .with_dummy_content()
+               .within(gallery)
+               .with_modification_date(DateTime("2014-01-01")))
+
+        create(Builder('image')
+               .titled('b_img')
+               .with_dummy_content()
+               .within(gallery)
+               .with_modification_date(DateTime("2016-01-01")))
+
+        create(Builder('image')
+               .titled('c_img')
+               .with_dummy_content()
+               .within(gallery)
+               .with_modification_date(DateTime("2015-01-01")))
+
+        browser.login().visit(self.page)
+
+        img_list = browser.css('.colorboxLink img')
+        img_title_list = []
+
+        for img in img_list:
+            img_title_list.append(img.get('alt').split(',')[0])
+
+        self.assertEqual(img_title_list, ['a_img', 'c_img', 'b_img'])
+
+    @browsing
+    def test_sort_by_modified_descending(self, browser):
+        gallery = create(Builder('sl galleryblock')
+                         .titled('My galleryblock')
+                         .having(sort_on='modified')
+                         .having(sort_order='descending')
+                         .within(self.page))
+
+        create(Builder('image')
+               .titled('a_img')
+               .with_dummy_content()
+               .within(gallery)
+               .with_modification_date(DateTime("2014-01-01")))
+
+        create(Builder('image')
+               .titled('b_img')
+               .with_dummy_content()
+               .within(gallery)
+               .with_modification_date(DateTime("2016-01-01")))
+
+        create(Builder('image')
+               .titled('c_img')
+               .with_dummy_content()
+               .within(gallery)
+               .with_modification_date(DateTime("2015-01-01")))
+
+        browser.login().visit(self.page)
+
+        img_list = browser.css('.colorboxLink img')
+        img_title_list = []
+
+        for img in img_list:
+            img_title_list.append(img.get('alt').split(',')[0])
+
+        self.assertEqual(img_title_list, ['b_img', 'c_img', 'a_img'])


### PR DESCRIPTION
The galleryblock now has 2 sort options just like the file listingblock.

![bildschirmfoto 2016-06-27 um 11 20 12](https://cloud.githubusercontent.com/assets/16755391/16374941/256d66ac-3c59-11e6-8b48-32dc3b6b9e34.png)