### PR TITLE
Add min-height to empty Simplelyout portlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add min-height to empty Simplelyout portlet.
+  This fixes a issue, when it was no longer possible to re-add a layout after deleting the last one.
+  [mathias.leimgruber]
 
 
 1.5.2 (2016-05-26)

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -462,11 +462,20 @@ ul[class^="sl-toolbar"] {
 }
 
 .SimplelayoutPortlet {
- .sl-column {
-  min-height: 100px;
-    &:empty {
-      border: 1px dashed $color-text;
-      margin-bottom: $margin-vertical;
+
+  .sl-can-edit {
+    &.sl-simplelayout {
+      min-height: 100px;
+    }
+    .sl-layout {
+      min-height: 100px;
+    }
+   .sl-column {
+    min-height: 100px;
+      &:empty {
+        border: 1px dashed $color-text;
+        margin-bottom: $margin-vertical;
+      }
     }
   }
 }


### PR DESCRIPTION
This fixes a issue, when it was no longer possible to re-add a layout after deleting the last one.