### PR TITLE
Fix floating images on mobile view.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
+- Fix floating images on mobile view.
+  [Kevin Bieri]
+
 - Make simplelayout events globally available.
   [raphael-s]
 

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -11,10 +11,14 @@
   width: 100%;
 
   &.left {
-    float: left;
+    @include screen-small() {
+      float: left;
+    }
   }
   &.right {
-    float: right;
+    @include screen-small() {
+      float: right;
+    }
   }
   &.sl_textblock_small{
     @include screen-small() {


### PR DESCRIPTION
The images in a simplelayout block should not float if they are full width.
This issue breaks the bullets of the listing for example.

Before:
![bildschirmfoto 2016-07-12 um 13 52 41](https://cloud.githubusercontent.com/assets/1637820/16766077/10b7bd58-4838-11e6-9e88-554c2c137396.png)

After:
![bildschirmfoto 2016-07-12 um 13 51 56](https://cloud.githubusercontent.com/assets/1637820/16766079/13e4e83e-4838-11e6-8dd3-e50e78a1c3b1.png)
