### PR TITLE
Translate quickupload title in overlay for filelistings and galleryblocks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
+- Translate quickupload title in overlay for filelistings and galleryblocks.
+  [elioschmutz]
+
 - Fix floating images on mobile view.
   [Kevin Bieri]
 

--- a/ftw/simplelayout/locales/collective.quickupload.pot
+++ b/ftw/simplelayout/locales/collective.quickupload.pot
@@ -1,0 +1,20 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2015-06-22 10:11+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
+msgid "label_media_quickupload"
+msgstr ""

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/collective.quickupload.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/collective.quickupload.po
@@ -1,0 +1,18 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2015-06-22 10:11+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
+msgid "label_media_quickupload"
+msgstr "Dateien hochladen"
+


### PR DESCRIPTION
The title of the quickupload overlay is not translated properly in german.

This PR will translate the overlay title.

Before
-------
![bildschirmfoto 2016-07-13 um 17 57 37](https://cloud.githubusercontent.com/assets/557005/16810228/725318b4-4923-11e6-8e36-69746d2bfe93.png)

After
-----
![bildschirmfoto 2016-07-13 um 17 58 32](https://cloud.githubusercontent.com/assets/557005/16810225/7061190c-4923-11e6-879d-665baddf794d.png)
