### PR TITLE
Use zindex system from ftw.theming

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.5.3 (unreleased)
 ------------------
 
+- Use zindex system from ftw.theming
+  Fix iframeblock boundaries
+  [Kevin Bieri]
+
 - Display default youtube player controls
   [Kevin Bieri]
 

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -139,7 +139,7 @@
     display: none;
     position: absolute;
     opacity: 0.001;
-    z-index: 1000;
+    z-index: $zindex-overlay;
     background-color: $color-content-background;
   }
 }
@@ -239,7 +239,7 @@ ul[class^="sl-toolbar"] {
   background-color: $color-text;
   visibility: hidden;
   border-radius: $border-radius-primary;
-  z-index: 4;
+  z-index: $zindex-tooltip;
   li {
     text-align: center;
     a {
@@ -285,7 +285,7 @@ ul[class^="sl-toolbar"] {
   right: 0;
   top: 0;
   height: 100%;
-  z-index: 1;
+  z-index: $zindex-tooltip;
   display: table;
   background: $color-text;
 

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -104,6 +104,7 @@
   }
 
   iframe {
+    float: left;
     @include ie-only() {
       pointer-events: none;
     }


### PR DESCRIPTION
Also fixes iframeblock boundaries:

Before:
![bildschirmfoto 2016-07-14 um 17 23 57](https://cloud.githubusercontent.com/assets/1637820/16845284/a5fbe522-49e8-11e6-907c-78e0d784d880.png)

After:
![bildschirmfoto 2016-07-14 um 17 24 05](https://cloud.githubusercontent.com/assets/1637820/16845289/a99d4694-49e8-11e6-94d6-b8c5a1081b12.png)
