### PR TITLE
Uninstall profile for mapblock and contenttypes extras

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add uninstall profile for ftw.simplelayout.mapblock.
+  [elioschmutz]
 
 
 1.6.0 (2016-07-18)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
+- Add uninstall profile for ftw.simplelayout.contenttypes.
+  [elioschmutz]
+
 - Add uninstall profile for ftw.simplelayout.mapblock.
   [elioschmutz]
 

--- a/ftw/simplelayout/contenttypes/Extensions/install.py
+++ b/ftw/simplelayout/contenttypes/Extensions/install.py
@@ -1,0 +1,8 @@
+from Products.CMFCore.utils import getToolByName
+
+
+def uninstall(self):
+    setup_tool = getToolByName(self, 'portal_setup')
+    setup_tool.runAllImportStepsFromProfile(
+        'profile-ftw.simplelayout.contenttypes:uninstall',
+        ignore_dependencies=True)

--- a/ftw/simplelayout/contenttypes/__init__.py
+++ b/ftw/simplelayout/contenttypes/__init__.py
@@ -1,0 +1,4 @@
+def initialize(context):
+    """Required for beeing able to uninstall the contenttypes product.
+    """
+    pass

--- a/ftw/simplelayout/contenttypes/configure.zcml
+++ b/ftw/simplelayout/contenttypes/configure.zcml
@@ -1,5 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:five="http://namespaces.zope.org/five"
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     xmlns:plone="http://namespaces.plone.org/plone"
@@ -7,6 +8,8 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     xmlns:browser="http://namespaces.zope.org/browser"
     i18n_domain="ftw.simplelayout">
+
+    <five:registerPackage package="." initialize=".initialize" />
 
     <include package="plone.behavior" file="meta.zcml" />
 
@@ -29,6 +32,15 @@
         directory="profiles/default"
         description="Simlelayout default content types"
         provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        name="uninstall"
+        title="Uninstall ftw.simplelayout.contenttypes"
+        directory="profiles/uninstall"
+        description="Uninstalls the ftw.simplelayout.contenttypes package."
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
         />
 
     <upgrade-step:directory

--- a/ftw/simplelayout/contenttypes/profiles/uninstall/jsregistry.xml
+++ b/ftw/simplelayout/contenttypes/profiles/uninstall/jsregistry.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+
+    <javascript id="++resource++ftw.simplelayout.resources/videoblock.js" remove="True" />
+
+</object>

--- a/ftw/simplelayout/contenttypes/profiles/uninstall/propertiestool.xml
+++ b/ftw/simplelayout/contenttypes/profiles/uninstall/propertiestool.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+ <object name="navtree_properties" meta_type="Plone Property Sheet">
+  <property name="metaTypesNotToList" type="lines" purge="False">
+   <element value="ftw.simplelayout.TextBlock" remove="True"/>
+   <element value="ftw.simplelayout.FileListingBlock" remove="True"/>
+   <element value="ftw.simplelayout.VideoBlock" remove="True"/>
+   <element value="ftw.simplelayout.GalleryBlock" remove="True"/>
+  </property>
+ </object>
+
+ <object name="site_properties" meta_type="Plone Property Sheet">
+  <property name="types_not_searched" type="lines" purge="False">
+   <element value="ftw.simplelayout.TextBlock" remove="True"/>
+   <element value="ftw.simplelayout.FileListingBlock" remove="True"/>
+   <element value="ftw.simplelayout.VideoBlock" remove="True"/>
+   <element value="ftw.simplelayout.GalleryBlock" remove="True"/>
+  </property>
+  <property name="default_page_types" type="lines" purge="False">
+   <element value="ftw.simplelayout.ContentPage" remove="True"/>
+  </property>
+ </object>
+
+ <object name="imaging_properties" meta_type="Plone Property Sheet">
+  <property name="allowed_sizes" type="lines" purge="False">
+   <element value="simplelayout_galleryblock 480:480" remove="True"/>
+   <element value="sl_textblock_small 480:480" remove="True"/>
+   <element value="sl_textblock_middle 800:800" remove="True"/>
+   <element value="sl_textblock_large 1280:1280" remove="True"/>
+  </property>
+ </object>
+
+</object>

--- a/ftw/simplelayout/contenttypes/profiles/uninstall/rolemap.xml
+++ b/ftw/simplelayout/contenttypes/profiles/uninstall/rolemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="ftw.simplelayout: Add ContentPage" acquire="True"></permission>
+    <permission name="ftw.simplelayout: Add TextBlock" acquire="True"></permission>
+    <permission name="ftw.simplelayout: Add FileListingBlock" acquire="True"></permission>
+    <permission name="ftw.simplelayout: Add VideoBlock" acquire="True"></permission>
+    <permission name="ftw.simplelayout: Add GalleryBlock" acquire="True"></permission>
+  </permissions>
+</rolemap>

--- a/ftw/simplelayout/contenttypes/profiles/uninstall/tinymce.xml
+++ b/ftw/simplelayout/contenttypes/profiles/uninstall/tinymce.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<object>
+    <resourcetypes>
+
+        <linkable purge="False">
+            <element value="ftw.simplelayout.ContentPage" remove="True"/>
+            <element value="ftw.simplelayout.FileListingBlock" remove="True"/>
+            <element value="ftw.simplelayout.GalleryBlock" remove="True"/>
+            <element value="ftw.simplelayout.TextBlock" remove="True"/>
+            <element value="ftw.simplelayout.VideoBlock" remove="True"/>
+        </linkable>
+
+        <containsobjects purge="False">
+            <element value="ftw.simplelayout.ContentPage" remove="True"/>
+            <element value="ftw.simplelayout.FileListingBlock" remove="True"/>
+            <element value="ftw.simplelayout.GalleryBlock" remove="True"/>
+        </containsobjects>
+
+    </resourcetypes>
+</object>

--- a/ftw/simplelayout/contenttypes/profiles/uninstall/types.xml
+++ b/ftw/simplelayout/contenttypes/profiles/uninstall/types.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+  <object name="ftw.simplelayout.ContentPage" meta_type="Dexterity FTI" remove="True" />
+  <object name="ftw.simplelayout.TextBlock" meta_type="Dexterity FTI" remove="True" />
+  <object name="ftw.simplelayout.FileListingBlock" meta_type="Dexterity FTI" remove="True" />
+  <object name="ftw.simplelayout.VideoBlock" meta_type="Dexterity FTI" remove="True" />
+  <object name="ftw.simplelayout.GalleryBlock" meta_type="Dexterity FTI" remove="True" />
+</object>

--- a/ftw/simplelayout/contenttypes/profiles/uninstall/types/Plone_Site.xml
+++ b/ftw/simplelayout/contenttypes/profiles/uninstall/types/Plone_Site.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<object name="Plone Site"
+   meta_type="Factory-based Type Information with dynamic views"
+   i18n:domain="plone" xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+
+ <property name="view_methods" purge="False">
+  <element value="simplelayout-view" remove="True"/>
+ </property>
+
+ <property name="allowed_content_types" purge="False">
+  <element value="ftw.simplelayout.ContentPage" remove="True"/>
+  <element value="ftw.simplelayout.TextBlock" remove="True"/>
+  <element value="ftw.simplelayout.FileListingBlock" remove="True"/>
+  <element value="ftw.simplelayout.VideoBlock" remove="True"/>
+  <element value="ftw.simplelayout.GalleryBlock" remove="True"/>
+ </property>
+
+
+</object>

--- a/ftw/simplelayout/contenttypes/profiles/uninstall/workflows.xml
+++ b/ftw/simplelayout/contenttypes/profiles/uninstall/workflows.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+ <bindings>
+  <type type_id="ftw.simplelayout.TextBlock" remove="True"/>
+  <type type_id="ftw.simplelayout.FileListingBlock" remove="True"/>
+  <type type_id="ftw.simplelayout.VideoBlock" remove="True"/>
+  <type type_id="ftw.simplelayout.GalleryBlock" remove="True"/>
+ </bindings>
+</object>

--- a/ftw/simplelayout/mapblock/Extensions/install.py
+++ b/ftw/simplelayout/mapblock/Extensions/install.py
@@ -1,0 +1,8 @@
+from Products.CMFCore.utils import getToolByName
+
+
+def uninstall(self):
+    setup_tool = getToolByName(self, 'portal_setup')
+    setup_tool.runAllImportStepsFromProfile(
+        'profile-ftw.simplelayout.mapblock:uninstall',
+        ignore_dependencies=True)

--- a/ftw/simplelayout/mapblock/__init__.py
+++ b/ftw/simplelayout/mapblock/__init__.py
@@ -1,0 +1,4 @@
+def initialize(context):
+    """Required for beeing able to uninstall the mapblock product.
+    """
+    pass

--- a/ftw/simplelayout/mapblock/configure.zcml
+++ b/ftw/simplelayout/mapblock/configure.zcml
@@ -6,6 +6,8 @@
     xmlns:zcml="http://namespaces.zope.org/zcml"
     i18n_domain="ftw.simplelayout">
 
+    <five:registerPackage package="." initialize=".initialize" />
+
     <include file="permissions.zcml" />
     <include package=".browser" />
     <include package=".contents" />
@@ -18,6 +20,15 @@
         directory="profiles/default"
         description="Simlelayout map block type"
         provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        name="uninstall"
+        title="Uninstall ftw.simplelayout.mapblocks"
+        directory="profiles/uninstall"
+        description="Uninstalls the ftw.simplelayout.mapblocks package."
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        for="Products.CMFPlone.interfaces.IMigratingPloneSiteRoot"
         />
 
 </configure>

--- a/ftw/simplelayout/mapblock/profiles/uninstall/jsregistry.xml
+++ b/ftw/simplelayout/mapblock/profiles/uninstall/jsregistry.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_javascripts">
+
+    <javascript id="++resource++ftw.simplelayout.mapblock.resources/mapblock.js" remove="True" />
+
+</object>

--- a/ftw/simplelayout/mapblock/profiles/uninstall/propertiestool.xml
+++ b/ftw/simplelayout/mapblock/profiles/uninstall/propertiestool.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+ <object name="navtree_properties" meta_type="Plone Property Sheet">
+  <property name="metaTypesNotToList" type="lines" purge="False">
+   <element value="ftw.simplelayout.MapBlock" remove="True"/>
+  </property>
+ </object>
+
+ <object name="site_properties" meta_type="Plone Property Sheet">
+  <property name="types_not_searched" type="lines" purge="False">
+   <element value="ftw.simplelayout.MapBlock" remove="True"/>
+  </property>
+ </object>
+
+</object>

--- a/ftw/simplelayout/mapblock/profiles/uninstall/rolemap.xml
+++ b/ftw/simplelayout/mapblock/profiles/uninstall/rolemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="ftw.simplelayout: Add MapBlock" acquire="True">
+    </permission>
+  </permissions>
+</rolemap>

--- a/ftw/simplelayout/mapblock/profiles/uninstall/tinymce.xml
+++ b/ftw/simplelayout/mapblock/profiles/uninstall/tinymce.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object>
+    <resourcetypes>
+
+        <linkable purge="False">
+            <element value="ftw.simplelayout.MapBlock" remove="True" />
+        </linkable>
+
+    </resourcetypes>
+</object>

--- a/ftw/simplelayout/mapblock/profiles/uninstall/types.xml
+++ b/ftw/simplelayout/mapblock/profiles/uninstall/types.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<object name="portal_types" meta_type="Plone Types Tool">
+  <object name="ftw.simplelayout.MapBlock" meta_type="Dexterity FTI" remove="True" />
+</object>

--- a/ftw/simplelayout/mapblock/profiles/uninstall/workflows.xml
+++ b/ftw/simplelayout/mapblock/profiles/uninstall/workflows.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<object name="portal_workflow" meta_type="Plone Workflow Tool">
+ <bindings>
+  <type type_id="ftw.simplelayout.MapBlock" remove="True"/>
+ </bindings>
+</object>

--- a/ftw/simplelayout/tests/test_uninstall.py
+++ b/ftw/simplelayout/tests/test_uninstall.py
@@ -1,0 +1,8 @@
+from ftw.testing.genericsetup import GenericSetupUninstallMixin
+from ftw.testing.genericsetup import apply_generic_setup_layer
+from unittest2 import TestCase
+
+
+@apply_generic_setup_layer
+class TestGenericSetupUninstallMapBlock(TestCase, GenericSetupUninstallMixin):
+    package = 'ftw.simplelayout.mapblock'

--- a/ftw/simplelayout/tests/test_uninstall.py
+++ b/ftw/simplelayout/tests/test_uninstall.py
@@ -6,3 +6,8 @@ from unittest2 import TestCase
 @apply_generic_setup_layer
 class TestGenericSetupUninstallMapBlock(TestCase, GenericSetupUninstallMixin):
     package = 'ftw.simplelayout.mapblock'
+
+
+@apply_generic_setup_layer
+class TestGenericSetupUninstallContentTypes(TestCase, GenericSetupUninstallMixin):
+    package = 'ftw.simplelayout.contenttypes'


### PR DESCRIPTION
This PR adds adds uninstall profiles for the following extras:

- mapblock
- contenttypes
