### PR TITLE
Fix toolbox label zindex

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.6.1 (unreleased)
 ------------------
 
+- Fix toolbox label zindex
+  [Kevin Bieri]
+
 - Add IE11 fix for InAndOutWidget Javascript.
   In IE11 it's not possible to manipulate a select (multiple) after
   modifying the text of a option.

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -277,7 +277,7 @@ ul[class^="sl-toolbar"] {
   right: 0;
   top: 0;
   height: 100%;
-  z-index: $zindex-tooltip;
+  z-index: $zindex-overlay - 10;
   display: table;
   background: $color-text;
 


### PR DESCRIPTION
See https://github.com/4teamwork/winterthur.web/issues/176

⚠️  Depends on https://github.com/4teamwork/plonetheme.blueberry/pull/90

The toolbox label should be treated as an overlay
because it should overlap everything on the page but
the editoverlay