### PR TITLE
Fix word break inside listing block tables

### DIFF
--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -70,21 +70,22 @@
       }
       td {
 
+        text-align: left;
+
         &.column-modified {
-          width: 85px;
+          white-space: nowrap;
         }
 
         &.column-portal_type {
-          width: 25px;
-          padding-right: 0;
+          white-space: nowrap;
         }
 
         &.column-getObjSize {
-          width: 75px;
+          white-space: nowrap;
         }
 
-        &:last-child:not(.column-sortable_title){
-          text-align: right;
+        &.column-id {
+          white-space: nowrap;
         }
 
         img {


### PR DESCRIPTION
See https://github.com/4teamwork/winterthur.web/issues/174

The author is responsible to choose the right amount of columns to make the page good looking

Before:
<img width="1226" alt="screen shot 2016-08-05 at 14 48 25" src="https://cloud.githubusercontent.com/assets/1637820/17437078/d0730562-5b1b-11e6-9908-0c6b6a8799a4.png">
<img width="747" alt="screen shot 2016-08-05 at 14 48 46" src="https://cloud.githubusercontent.com/assets/1637820/17437079/d078053a-5b1b-11e6-934d-d34bcfb80978.png">

After:
<img width="1155" alt="screen shot 2016-08-05 at 14 49 01" src="https://cloud.githubusercontent.com/assets/1637820/17437086/db1b9e5c-5b1b-11e6-9f23-4ded3e0cc158.png">
<img width="1268" alt="screen shot 2016-08-05 at 14 49 14" src="https://cloud.githubusercontent.com/assets/1637820/17437087/db1fc310-5b1b-11e6-82a3-d945dba7c415.png">
