### PR TITLE
Add Expand icon for colorbox images.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add an icon to mark an colorbox image.
+  [tschanzt]
 
 
 1.7.1 (2016-08-05)

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -9,6 +9,7 @@
 
 .sl-image {
   width: 100%;
+  position: relative;
 
   &.left {
     @include screen-small() {

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -36,6 +36,27 @@
   }
 }
 
+.icons-on .sl-image .colorboxLink{
+  @extend .fa-expand;
+  @extend .fa-icon;
+
+  &:before {
+    color: white;
+    position: absolute;
+    bottom: 0px;
+    right: 0px;
+    font-size: 1.5em;
+    background: rgb(0,0,0);
+    opacity: 0.5;
+    border-radius: 2px;
+    padding: 2px 0px 1px 0px;
+  }
+
+  &:hover:before {
+    opacity: 1;
+  }
+}
+
 .ui-sortable-disabled .sl-layout:hover .sl-toolbar-layout {
   opacity: 0;
 }


### PR DESCRIPTION
@maethu I added an expand icon for colorbox images. 
![screen shot 2016-08-09 at 08 52 09](https://cloud.githubusercontent.com/assets/358342/17508365/e2f6eef0-5e14-11e6-9218-306211f78c43.png)
