### PR TITLE
Set permissions for change layout

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.7.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Set permission for change layout, site admin & manager now have permission to change the layout.
+  [raphael-s]
 
 
 1.7.4 (2016-08-16)

--- a/ftw/simplelayout/profiles/lib/rolemap.xml
+++ b/ftw/simplelayout/profiles/lib/rolemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="ftw.simplelayout: Change Layouts" acquire="False">
+      <role name="Manager" />
+      <role name="Site Administrator"/>
+    </permission>
+  </permissions>
+</rolemap>

--- a/ftw/simplelayout/upgrades/20160816120005_configure_change_layout_permissions/rolemap.xml
+++ b/ftw/simplelayout/upgrades/20160816120005_configure_change_layout_permissions/rolemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+    <permission name="ftw.simplelayout: Change Layouts" acquire="False">
+      <role name="Manager" />
+      <role name="Site Administrator"/>
+    </permission>
+  </permissions>
+</rolemap>

--- a/ftw/simplelayout/upgrades/20160816120005_configure_change_layout_permissions/upgrade.py
+++ b/ftw/simplelayout/upgrades/20160816120005_configure_change_layout_permissions/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ConfigureChangeLayoutPermissions(UpgradeStep):
+    """Configure change layout permissions.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Sets permission for change layout, site admin & manager can now have permission to change the layout.
Also includes an upgrade step for the new permissions.

closes #342 