### PR TITLE
Fix image overlay in textblock

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.7.5 (unreleased)
 ------------------
 
+- Fix image overlay in textblocks
+  [Kevin Bieri]
+
 - Set permission for change layout, site admin & manager now have permission to change the layout.
   [raphael-s]
 

--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -141,6 +141,7 @@
           block.content(data.content);
           block.commit();
           saveState();
+          initializeColorbox();
           this.close();
         });
         addOverlay.onCancel(function() {


### PR DESCRIPTION
The colorbox does not get initialized when adding
a textblock with an image.