### PR TITLE
fix icon with image description

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Fix Icon position. It is now postitioned to the image not the container.
+  [tschanzt]
+
 - Add optional title to the video block (disabled by default).
   [mbaechtold]
 

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -36,6 +36,10 @@
   }
 }
 
+.icons-on .sl-image .imageContainer {
+    position:relative;
+}
+
 .icons-on .sl-image .colorboxLink{
   @extend .fa-expand;
   @extend .fa-icon;

--- a/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
@@ -14,12 +14,14 @@
 
   <tal:image tal:condition="image">
     <div tal:attributes="class image/wrapper_css_classes">
-        <a tal:omit-tag="not: image/link_url"
-           tal:attributes="href image/link_url;
-                           title image/link_title;
-                           class image/link_css_classes">
-            <img tal:replace="structure image/image_tag" />
-        </a>
+        <div class="imageContainer">
+            <a tal:omit-tag="not: image/link_url"
+               tal:attributes="href image/link_url;
+                               title image/link_title;
+                               class image/link_css_classes">
+                <img tal:replace="structure image/image_tag" />
+            </a>
+        </div>
         <div class="hiddenStructure" i18n:translate="hidden_label_image_caption">Image caption:</div>
         <div class="image-caption" tal:content="context/image_caption" />
     </div>


### PR DESCRIPTION
@maethu I added an additional div which allows me to place the icon relative to the image, since it only contains the image instead of the complete content with caption.