### PR TITLE
Fix drop animation

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.7.5 (unreleased)
 ------------------
 
+- Fix drop animation backgroundcolor
+  [Kevin Bieri]
+
 - Make leadimages "has_image" and "get_scale" usable. [jone]
 
 - BugFix: Copyied event is called recursively. Check if the block is actually part of the current page.

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -144,9 +144,8 @@
     opacity: 1;
     visibility: visible;
   }
-  &.animated {
-    opacity: 0;
-    background: $color-content-background;
+  &.dropped {
+    @include animation(fade, 1s ease-in-out)
   }
   .iFrameFix {
     width: 100%;
@@ -502,4 +501,10 @@ ul[class^="sl-toolbar"] {
 
 .overlay-open {
   overflow: hidden;
+}
+
+@include keyframes(fade) {
+  0%   { background-color: transparent; }
+  50%   { background-color: #fff3a5; }
+  100% { background-color: transparent; }
 }

--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -154,14 +154,8 @@
       simplelayout.restore(target);
 
       simplelayout.on("block-committed", function(block) {
-        block.element.css("opacity", "0");
-        block.element.animate(
-          { opacity: 1, backgroundColor: "#fff3a5" },
-          300,
-          function() {
-            $(this).animate({ backgroundColor: "#fff" }, 300);
-          }
-        );
+        block.element.on("animationend webkitAnimationEnd", function() { block.element.removeClass("dropped"); });
+        block.element.addClass("dropped");
       });
 
       simplelayout.on("blockDeleted", function(block) {


### PR DESCRIPTION
The drop animation changed the background color of the dropped
element to `#fff`. The background-color should not be done using
style attribute because overriding these styles requires an `!important`
statement in the CSS.

![drop_animation](https://cloud.githubusercontent.com/assets/1637820/17929095/8eabcee2-69fe-11e6-955c-aff7759392c9.gif)