### PR TITLE
Make leadimages "has_image" and "get_scale" usable.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.7.5 (unreleased)
 ------------------
 
+- Make leadimages "has_image" and "get_scale" usable. [jone]
+
 - BugFix: Copyied event is called recursively. Check if the block is actually part of the current page.
   [mathias.leimgruber]
 

--- a/ftw/simplelayout/opengraph/og_sl_page.py
+++ b/ftw/simplelayout/opengraph/og_sl_page.py
@@ -30,7 +30,6 @@ class SimplelayoutPageOpenGraph(PloneRootOpenGraph):
     def get_image_url(self):
         """OG image"""
         leadimage_view = self.context.restrictedTraverse('@@leadimage')
-        leadimage_view._get_image()
         if leadimage_view.has_image:
             scale = leadimage_view.get_scale()
             return scale and scale.url or ''


### PR DESCRIPTION
Before, one had to call `_get_image`, an internal method, in order to
update the view state so that `has_image` and `get_scale` would work as
expected. This is not how public methods should work.

By refactoring it this way I try to not change the public interface but
fix the state issues by auto-loading internally when not yet done.