### PR TITLE
Add textblock descriptions

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
+- Add field description for 'Image alternative text' and 'Open image in overlay'.
+  [raphael-s]
+
 - Fix Icon position. It is now postitioned to the image not the container.
   [tschanzt]
 

--- a/ftw/simplelayout/contenttypes/contents/textblock.py
+++ b/ftw/simplelayout/contenttypes/contents/textblock.py
@@ -49,7 +49,9 @@ class ITextBlockSchema(form.Schema):
 
     image_alt_text = schema.TextLine(
         title=_(u'label_image_alt_text', default=u'Image alternative text'),
-        required=False)
+        required=False,
+        description=_(u'description_image_alt_text',
+                      default=u'Enter an alternative text for the image'))
 
     image_caption = schema.TextLine(
         title=_(u'label_image_caption', default=u'Image caption'),
@@ -60,7 +62,9 @@ class ITextBlockSchema(form.Schema):
                 default=u'Open image in overlay'
                 u' (only if there is no teaser url)'),
         default=False,
-        required=False)
+        required=False,
+        description=_(u'description_image_clickable',
+                      default=u'Opens image in an overlay'))
 
 
 alsoProvides(ITextBlockSchema, IFormFieldProvider)

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/collective.quickupload.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/collective.quickupload.po
@@ -1,0 +1,21 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2015-06-22 10:11+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+#: ../browser/quick_upload.py:206
+#: ../portlet/quickuploadportlet.py:134
+msgid "label_media_quickupload"
+msgstr ""
+

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -1,3 +1,6 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
@@ -13,15 +16,15 @@ msgstr ""
 
 #: ./ftw/simplelayout/behaviors.zcml:24
 msgid "Adds checkbox to hide title of a contentpage"
-msgstr "Fügt eine checkbox hinzu, mit der der Titel einer Inhaltsseite versteckt werden kann"
+msgstr ""
 
 #: ./ftw/simplelayout/browser/ajax/edit_block.py:48
 msgid "Cancel"
-msgstr "Abbrechen"
+msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:112
 msgid "Check possible values on http://ogp.me"
-msgstr "Prüfe mögliche Werte auf http://ogp.me"
+msgstr ""
 
 #: ./ftw/simplelayout/mapblock/configure.zcml:51
 msgid "Collective Geo Maps"
@@ -29,23 +32,23 @@ msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.ContentPage.xml
 msgid "ContentPage"
-msgstr "Inhaltsseite"
+msgstr ""
 
 #: ./ftw/simplelayout/behaviors.zcml:24
 msgid "Contentpage show title behavior"
-msgstr "Inhaltsseite show title behavior"
+msgstr ""
 
 #: ./ftw/simplelayout/mapblock/behavior.py:15
 msgid "Coordinates"
-msgstr "Koordinaten"
+msgstr ""
 
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:61
 msgid "Delete"
-msgstr "Löschen"
+msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:105
 msgid "Enable OpenGraph support on plone root"
-msgstr "Aktiviere den OpenGraph Support auf dem Plone Root"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/configure.zcml:27
 msgid "Extends a content by two fields internal and external link"
@@ -53,24 +56,24 @@ msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
 msgid "FileListingBlock"
-msgstr "Dateiauflistung"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.GalleryBlock.xml
 msgid "GalleryBlock"
-msgstr "Bildergalerie"
+msgstr ""
 
 #. Default: "ID"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:70
 msgid "ID"
-msgstr "ID"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:25
 msgid "Image"
-msgstr "Bild"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/behaviors.py:40
 msgid "It's not possible to have an internal_link and an external_link together"
-msgstr "Es ist nicht möglich, einen internen und externen Link gleichzeitig zu definieren."
+msgstr ""
 
 #: ./ftw/simplelayout/configure.zcml:73
 msgid "Javascript resources from client are not compressed"
@@ -78,27 +81,27 @@ msgstr ""
 
 #: ./ftw/simplelayout/mapblock/profiles/default/types/ftw.simplelayout.MapBlock.xml
 msgid "MapBlock"
-msgstr "Karte"
+msgstr ""
 
 #: ./ftw/simplelayout/mapblock/behavior.py:16
 msgid "Modify geographical data for this content"
-msgstr "Ändere die geographischen Daten für diesen Inhalt"
+msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:111
 msgid "OpenGraph global type"
-msgstr "Globaler OpenGraph Typ"
+msgstr ""
 
 #: ./ftw/simplelayout/browser/ajax/edit_block.py:37
 msgid "Save"
-msgstr "Speichern"
+msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:30
 msgid "Show title"
-msgstr "Zeige Titel"
+msgstr ""
 
 #: ./ftw/simplelayout/opengraph/configure.zcml:32
 msgid "Shows OpenGraph meta tags"
-msgstr "Zeigt die OpenGraph Meta Tags"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/configure.zcml:35
 msgid "Simlelayout default content types"
@@ -118,7 +121,7 @@ msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/configure.zcml:58
 msgid "Simplelayout View"
-msgstr "Simplelayout Ansicht"
+msgstr ""
 
 #: ./ftw/simplelayout/behaviors.zcml:18
 msgid "Simplelayout block behavior"
@@ -130,12 +133,12 @@ msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:95
 msgid "Simplelayout default configuration"
-msgstr "Simplelayout Standard-Konfiguration"
+msgstr ""
 
 #: ./ftw/simplelayout/profiles/lib-plone5/controlpanel.xml
 #: ./ftw/simplelayout/profiles/lib/controlpanel.xml
 msgid "Simplelayout default settings"
-msgstr "Simplelayout Standard-Einstellungen"
+msgstr ""
 
 #: ./ftw/simplelayout/behaviors.zcml:12
 msgid "Simplelayout page"
@@ -147,7 +150,7 @@ msgstr ""
 
 #: ./ftw/simplelayout/browser/controlpanel/simplelayout_controlpanel.py:16
 msgid "Simplelayout settings"
-msgstr "Simplelayout Einstellungen"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/configure.zcml:27
 msgid "Simplelayout teaser behavior"
@@ -155,137 +158,137 @@ msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/behaviors.py:17
 msgid "Teaser"
-msgstr "Link"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.TextBlock.xml
 msgid "TextBlock"
-msgstr "Text/Bild"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
 msgid "The file listing block renders a list of uploaded files with configurable header which can be used to change the order of the listing."
-msgstr "Der Dateiauflistungs-Block zeigt eine Liste von hochgeladenen Dateien an. Die Spaltenüberschriften der Auflistung sind konfigurierbar und können verwendet werden, um die Auflistung zu sortieren."
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.GalleryBlock.xml
 msgid "The gallery block renders a variable amount of images as thumbnails and opens a larger image in an overlay."
-msgstr "Die Bildergalerie zeigt hochgeladene Bilder als Vorschau an. Die Bilder können in einer grösseren Variante in einem Overlay geöffnet werden."
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.TextBlock.xml
 msgid "The text block renders text and images."
-msgstr "Der Block \"Text/Bild\" zeigt Text und Bilder an."
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.VideoBlock.xml
 msgid "The video block renders videos loaded from YouTube or Vimeo."
-msgstr "Der Video-Block zeigt Videos von YouTube oder Vimeo an."
+msgstr ""
 
 #: ./ftw/simplelayout/mapblock/configure.zcml:51
 msgid "This behaviour will make a content geo referenceable"
-msgstr "Dieses behavior macht einen Inhalt geo-referenzierbar"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt:8
 #: ./ftw/simplelayout/contenttypes/browser/templates/listingblock.pt:10
 #: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:30
 msgid "This block is empty."
-msgstr "Dieser Block hat keinen Inhalt."
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/contents/videoblock.py:55
 msgid "This is no a valid youtube, or vimeo url."
-msgstr "Dies ist keine gültige Youtube- oder Vimeo-URL."
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/configure.zcml:44
 msgid "Uninstall ftw.simplelayout.contenttypes"
-msgstr "Deinstalliere ftw.simplelayout.contenttypes"
+msgstr ""
 
 #: ./ftw/simplelayout/mapblock/configure.zcml:34
 msgid "Uninstall ftw.simplelayout.mapblocks"
-msgstr "Deinstalliere ftw.simplelayout.mapblocks"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/configure.zcml:44
 msgid "Uninstalls the ftw.simplelayout.contenttypes package."
-msgstr "Deinstalliert das ftw.simplelayout.contenttypes Paket"
+msgstr ""
 
 #: ./ftw/simplelayout/mapblock/configure.zcml:34
 msgid "Uninstalls the ftw.simplelayout.mapblocks package."
-msgstr "Deinstalliert das ftw.simplelayout.mapblocks Paket"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.VideoBlock.xml
 msgid "VideoBlock"
-msgstr "Video"
+msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/contents/videoblock.py:43
 msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
-msgstr "Youtube Format: http(s)://youtu.be/VIDEO_ID<br/>Vimeo Format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
+msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:6
 msgid "alert_deleting_locked_item"
-msgstr "Dieser Eintrag kann nicht gelöscht werden, da er gerade von einem anderen Benutzer gesperrt ist."
+msgstr ""
 
 #. Default: "(This will delete a total of ${number_of_items_to_delete} items.)"
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:19
 msgid "alert_deleting_x_number_of_items"
-msgstr "(Diese Aktion wird ${number_of_items_to_delete} Einträge löschen.)"
+msgstr ""
 
 #. Default: "Do you really want to delete this item?"
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:23
 msgid "alert_really_delete"
-msgstr "Möchten Sie diesen Eintrag wirklich löschen?"
+msgstr ""
 
 #. Default: "Do you really want to delete this folder and all its contents?"
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:15
 msgid "alert_really_delete_folder"
-msgstr "Möchten Sie diesen Ordner und seinen Inhalt wirklich löschen?"
+msgstr ""
 
 #. Default: "creater"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:61
 msgid "column_creater"
-msgstr "Ersteller"
+msgstr ""
 
 #. Default: "modified"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:55
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:28
 msgid "column_modified"
-msgstr "Bearbeitet"
+msgstr ""
 
 #. Default: "size"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:66
 msgid "column_size"
-msgstr "Grösse"
+msgstr ""
 
 #. Default: "Title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:50
 msgid "column_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Type"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:45
 msgid "column_type"
-msgstr "Typ"
+msgstr ""
 
 #. Default: "Add Simplelayout defaultconfiguration, Check simplelayoutdocu: https://github.com/4teamwork/ftw.simplelayout#usage"
 #: ./ftw/simplelayout/interfaces.py:96
 msgid "desc_sl_config_control_panel"
-msgstr "Simplelayout Standard-Konfiguration hinzufügen, siehe Dokumentation: https://github.com/4teamwork/ftw.simplelayout#usage"
+msgstr ""
 
 #. Default: "Enter an alternative text for the image"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:53
 msgid "description_image_alt_text"
-msgstr "Geben Sie den Alternativtext für das Bild ein. Der Alternativtext richtet sich an Benutzer und Endgeräte,<br/> die den Bildinhalt nicht wahrnehmen oder nicht darstellen können, und sollte also wörtlich als Alternative<br/> zum Bild formuliert sein. Falls kein Alternativtext angegeben wird, wird der Bildtitel verwendet."
+msgstr "Saisissez un texte alternatif pour l'image"
 
 #. Default: "Opens image in an overlay"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:66
 msgid "description_image_clickable"
-msgstr "Wird das Bild angeklickt, öffnet es sich in einem Overlay"
+msgstr "Ouvre l'image dans un overlay"
 
 #. Default: "This will visually hide the block. This is not a security feature, the block and its content can still be accessed."
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:157
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:70
 msgid "description_is_hidden"
-msgstr "Dies versteckt den Block rein visuell. Dies ist kein Sicherheits-Feature, der Block und sein Inhalt bleibt immer noch aufrufbar."
+msgstr ""
 
 #. Default: "Use the teaser to redirect to another content or website.The title and the image of the block will be used to show a link"
 #: ./ftw/simplelayout/contenttypes/behaviors.py:19
 msgid "description_teaser_fieldset"
-msgstr "Mit der Link-Funktion kann ein Block direkt mit weiterführendem Inhalt verknüpft werden.<br /> Der Titel und das Bild vom Block werden als Link mit dem Ziel verknüpft.<br /><br /> Oft wird die Linkfunktion auch auf sogenannten Triage- oder Portal-Seiten verwendet. In diesen Fällen reicht ein Link in der Navigation nicht aus, sondern der Benutzer benötigt weitere Informationen, damit dieser auf der richten Seite landet."
+msgstr ""
 
 #: ./ftw/simplelayout/configure.zcml:73
 msgid "ftw.simplelayout development"
@@ -306,216 +309,216 @@ msgstr ""
 #. Default: "Please drag, no click required"
 #: ./ftw/simplelayout/browser/ajax/toolbox_view.py:95
 msgid "help_drag_hint"
-msgstr "Bitte den Inhalt per Drag & Drop hinzufügen."
+msgstr ""
 
 #. Default: "Image caption:"
 #: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:25
 msgid "hidden_label_image_caption"
-msgstr "Bild Legende:"
+msgstr ""
 
 #. Default: "${title}, enlarged picture."
 #: ./ftw/simplelayout/contenttypes/browser/galleryblock.py:39
 #: ./ftw/simplelayout/contenttypes/browser/textblock.py:83
 msgid "image_link_alttext"
-msgstr "${title}. Vergrösserte Ansicht"
+msgstr ""
 
 #. Default: "Delete block"
 #: ./ftw/simplelayout/browser/actions.py:37
 msgid "label:delete_block"
-msgstr "Block entfernen"
+msgstr ""
 
 #. Default: "sort_index"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:103
 msgid "label_%ssort_index"
-msgstr "Sortierung"
+msgstr ""
 
 #. Default: "Ascending"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:118
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:37
 msgid "label_ascending"
-msgstr "Aufsteigend"
+msgstr ""
 
 #. Default: "Cancel"
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:68
 msgid "label_cancel"
-msgstr "Abbrechen"
+msgstr ""
 
 #. Default: " Column(s)"
 #: ./ftw/simplelayout/browser/ajax/toolbox_view.py:90
 msgid "label_column_postfix"
-msgstr " Spalte(n)"
+msgstr ""
 
 #. Default: "Columns"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:138
 msgid "label_columns"
-msgstr "Spalten"
+msgstr ""
 
 #. Default: "Delete layout"
 #: ./ftw/simplelayout/browser/ajax/toolbox_view.py:81
 msgid "label_delete_layout"
-msgstr "Zeile löschen"
+msgstr ""
 
 #. Default: "Descending"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:120
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:39
 msgid "label_descending"
-msgstr "Absteigend"
+msgstr ""
 
 msgid "label_documentDate"
-msgstr "Dokumentdatum"
+msgstr ""
 
 #. Default: "Edit block"
 #: ./ftw/simplelayout/browser/actions.py:30
 msgid "label_edit_block"
-msgstr "Block bearbeiten"
+msgstr ""
 
 #. Default: "External URL"
 #: ./ftw/simplelayout/contenttypes/behaviors.py:28
 msgid "label_external_link"
-msgstr "Externe URL"
+msgstr ""
 
 #. Default: "Float image left"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:112
 msgid "label_float_image_left"
-msgstr "Bild links ausrichten"
+msgstr ""
 
 #. Default: "Float image right"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:151
 msgid "label_float_image_right"
-msgstr "Bild rechts ausrichten"
+msgstr ""
 
 #. Default: "Float large image left"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:121
 msgid "label_float_large_image_left"
-msgstr "Grosses Bild links ausrichten"
+msgstr ""
 
 #. Default: "Float large image right"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:141
 msgid "label_float_large_image_right"
-msgstr "Grosses Bild rechts ausrichten"
+msgstr ""
 
 #. Default: "Go to folder contents for managing files"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:187
 msgid "label_folder_contents_files"
-msgstr "Dateien über Inhalte verwalten."
+msgstr ""
 
 #. Default: "Go to folder contents for managing images"
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:100
 msgid "label_folder_contents_images"
-msgstr "Bilder über Inhalte verwalten."
+msgstr ""
 
 msgid "label_id"
-msgstr "ID"
+msgstr ""
 
 #. Default: "Image"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:47
 msgid "label_image"
-msgstr "Bild"
+msgstr ""
 
 #. Default: "Image alternative text"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:51
 msgid "label_image_alt_text"
-msgstr "Alternativer Text des Bildes"
+msgstr ""
 
 #. Default: "Image caption"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:57
 msgid "label_image_caption"
-msgstr "Bildlegende"
+msgstr ""
 
 #. Default: "Image without floating"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:131
 msgid "label_image_without_floating"
-msgstr "Bild ohne Ausrichtung"
+msgstr ""
 
 #. Default: "Internal link"
 #: ./ftw/simplelayout/contenttypes/behaviors.py:32
 msgid "label_internal_link"
-msgstr "Interne Referenz"
+msgstr ""
 
 #. Default: "Hide the block"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:156
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:69
 msgid "label_is_hidden"
-msgstr "Block verstecken"
+msgstr ""
 
 msgid "label_modified"
-msgstr "Bearbeitungsdatum"
+msgstr ""
 
 #. Default: "Move block"
 #: ./ftw/simplelayout/browser/actions.py:24
 msgid "label_move_block"
-msgstr "Block verschieben"
+msgstr ""
 
 #. Default: "Move layout"
 #: ./ftw/simplelayout/browser/ajax/toolbox_view.py:75
 msgid "label_move_layout"
-msgstr "Zeile verschieben"
+msgstr ""
 
 #. Default: "Open image in overlay (only if there is no teaser url)"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:61
 msgid "label_open_image_in_overlay"
-msgstr "Bild in Overlay öffnen (nur wenn kein Link hinterlegt ist)"
+msgstr ""
 
 msgid "label_portal_type"
-msgstr "Typ"
+msgstr ""
 
 #. Default: "Position in Folder"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:108
 msgid "label_position_in_folder"
-msgstr "Ordnerreihenfolge"
+msgstr ""
 
 #. Default: "Show title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:133
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:52
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:35
 msgid "label_show_title"
-msgstr "Titel anzeigen?"
+msgstr ""
 
 #. Default: "Title"
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
 msgid "label_sort_by_title"
-msgstr "Sortieren nach Titel"
+msgstr ""
 
 #. Default: "Sort by"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:144
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:57
 msgid "label_sort_on"
-msgstr "Sortieren nach"
+msgstr ""
 
 #. Default: "Sort order"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:150
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:63
 msgid "label_sort_order"
-msgstr "Sortierreihenfolge"
+msgstr ""
 
 msgid "label_sortable_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Text"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:41
 msgid "label_text"
-msgstr "Text"
+msgstr ""
 
 #. Default: "Title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:129
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:48
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:31
 msgid "label_title"
-msgstr "Titel"
+msgstr ""
 
 #. Default: "Upload"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:180
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:93
 msgid "label_upload"
-msgstr "Datei hochladen"
+msgstr ""
 
 #. Default: "Youtube, or Vimeo URL"
 #: ./ftw/simplelayout/contenttypes/contents/videoblock.py:42
 msgid "label_video_url"
-msgstr "Video-URL"
+msgstr ""
 
 #. Default: "These internal links will be broken"
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:37
 msgid "title_delete_link_check"
-msgstr "Folgende Inhalte haben interne Links auf diesen Inhalt:"
+msgstr ""
 

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-09-05 13:20+0000\n"
+"POT-Creation-Date: 2016-09-14 06:59+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -186,11 +186,11 @@ msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt:8
 #: ./ftw/simplelayout/contenttypes/browser/templates/listingblock.pt:10
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:28
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:30
 msgid "This block is empty."
 msgstr ""
 
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:46
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:55
 msgid "This is no a valid youtube, or vimeo url."
 msgstr ""
 
@@ -214,7 +214,7 @@ msgstr ""
 msgid "VideoBlock"
 msgstr ""
 
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:34
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:43
 msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
 msgstr ""
 
@@ -269,6 +269,16 @@ msgstr ""
 msgid "desc_sl_config_control_panel"
 msgstr ""
 
+#. Default: "Enter an alternative text for the image"
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:53
+msgid "description_image_alt_text"
+msgstr ""
+
+#. Default: "Opens image in an overlay"
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:66
+msgid "description_image_clickable"
+msgstr ""
+
 #. Default: "This will visually hide the block. This is not a security feature, the block and its content can still be accessed."
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:157
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:70
@@ -302,7 +312,7 @@ msgid "help_drag_hint"
 msgstr ""
 
 #. Default: "Image caption:"
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:23
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:25
 msgid "hidden_label_image_caption"
 msgstr ""
 
@@ -368,22 +378,22 @@ msgid "label_external_link"
 msgstr ""
 
 #. Default: "Float image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:108
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:112
 msgid "label_float_image_left"
 msgstr ""
 
 #. Default: "Float image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:147
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:151
 msgid "label_float_image_right"
 msgstr ""
 
 #. Default: "Float large image left"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:117
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:121
 msgid "label_float_large_image_left"
 msgstr ""
 
 #. Default: "Float large image right"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:137
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:141
 msgid "label_float_large_image_right"
 msgstr ""
 
@@ -411,12 +421,12 @@ msgid "label_image_alt_text"
 msgstr ""
 
 #. Default: "Image caption"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:55
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:57
 msgid "label_image_caption"
 msgstr ""
 
 #. Default: "Image without floating"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:127
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:131
 msgid "label_image_without_floating"
 msgstr ""
 
@@ -445,7 +455,7 @@ msgid "label_move_layout"
 msgstr ""
 
 #. Default: "Open image in overlay (only if there is no teaser url)"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:59
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:61
 msgid "label_open_image_in_overlay"
 msgstr ""
 
@@ -503,7 +513,7 @@ msgid "label_upload"
 msgstr ""
 
 #. Default: "Youtube, or Vimeo URL"
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:33
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:42
 msgid "label_video_url"
 msgstr ""
 


### PR DESCRIPTION
Adds description text for the image section in the textblock, `description_image_alt_text` and `description_image_clickable` are available in EN & DE & FR.

closes #374 