### PR TITLE
Add optional title to the video block (disabled by default).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add optional title to the video block (disabled by default).
+  [mbaechtold]
 
 
 1.8.1 (2016-09-06)

--- a/ftw/simplelayout/contenttypes/browser/templates/videoblock_vimeo.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/videoblock_vimeo.pt
@@ -1,1 +1,2 @@
+<h2 tal:content="view/block_title" tal:condition="view/block_title">Title</h2>
 <iframe tal:attributes="src view/vimeo_player" width="100%" height="500px" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>

--- a/ftw/simplelayout/contenttypes/browser/templates/videoblock_youtube.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/videoblock_youtube.pt
@@ -1,3 +1,4 @@
+<h2 tal:content="view/block_title" tal:condition="view/block_title">Title</h2>
 <div class="sl-youtube-video"
      tal:attributes="id view/get_uuid;
                      data-youtube view/youtube_config"></div>

--- a/ftw/simplelayout/contenttypes/contents/videoblock.py
+++ b/ftw/simplelayout/contenttypes/contents/videoblock.py
@@ -29,6 +29,15 @@ class IVideoBlockSchema(form.Schema):
     """VideoBlock for simplelayout
     """
 
+    title = schema.TextLine(
+        title=_(u'label_title', default=u'Title'),
+        required=False)
+
+    show_title = schema.Bool(
+        title=_(u'label_show_title', default=u'Show title'),
+        default=False,
+        required=False)
+
     video_url = schema.URI(
         title=_(u'label_video_url', default=u'Youtube, or Vimeo URL'),
         description=_(u'Youtube format: http(s)://youtu.be/VIDEO_ID<br/>'

--- a/ftw/simplelayout/tests/test_videoblock.py
+++ b/ftw/simplelayout/tests/test_videoblock.py
@@ -143,3 +143,47 @@ class TestTextBlockRendering(TestCase):
 
         videoblock_view = videoblock.restrictedTraverse('@@block_view')
         self.assertIsNone(videoblock_view.get_video_id())
+
+    @browsing
+    def test_youtube_video_block_title(self, browser):
+        videoblock = create(Builder('sl videoblock')
+                            .having(video_url='https://youtu.be/W42x6-Wf3Cs')
+                            .titled(u'A video on Youtube')
+                            .within(self.page))
+
+        browser.login()
+
+        # Make sure the title is not rendered by default.
+        browser.visit(videoblock, view='@@block_view')
+        self.assertEqual([], browser.css('h2'))
+
+        # Configure the block to render the title.
+        browser.visit(videoblock, view='edit')
+        browser.fill({'Show title': True}).submit()
+        browser.visit(videoblock, view='@@block_view')
+        self.assertEquals(
+            'A video on Youtube',
+            browser.css('h2').first.text
+        )
+
+    @browsing
+    def test_vimeo_block_title(self, browser):
+        videoblock = create(Builder('sl videoblock')
+                            .having(video_url='https://vimeo.com/channels/staffpicks/128510631')
+                            .titled(u'A video on Vimeo')
+                            .within(self.page))
+
+        browser.login()
+
+        # Make sure the title is not rendered by default.
+        browser.visit(videoblock, view='@@block_view')
+        self.assertEqual([], browser.css('h2'))
+
+        # Configure the block to render the title.
+        browser.visit(videoblock, view='edit')
+        browser.fill({'Show title': True}).submit()
+        browser.visit(videoblock, view='@@block_view')
+        self.assertEquals(
+            'A video on Vimeo',
+            browser.css('h2').first.text
+        )


### PR DESCRIPTION
The other blocks already have an optional title.