### PR TITLE
Protect new show/hide title behavior.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Protect new show/hide title behavior.
+  [mathias.leimgruber]
 
 
 1.8.2 (2016-09-14)

--- a/ftw/simplelayout/interfaces.py
+++ b/ftw/simplelayout/interfaces.py
@@ -3,6 +3,7 @@
 # E0213: Method should have "self" as first argument
 
 from ftw.simplelayout import _
+from plone.autoform import directives
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import model
 from zope import schema
@@ -31,6 +32,9 @@ class IContentPageShowTitle(model.Schema):
         default=True,
         required=False
     )
+
+    directives.write_permission(
+        show_title='ftw.simplelayout.HideTitle')
 
 
 class ISimplelayoutView(Interface):

--- a/ftw/simplelayout/lawgiver.zcml
+++ b/ftw/simplelayout/lawgiver.zcml
@@ -10,4 +10,9 @@
         permissions="ftw.simplelayout: Change Layouts"
         />
 
+    <lawgiver:map_permissions
+        action_group="manage content settings"
+        permissions="ftw.simplelayout: Hide title"
+        />
+
 </configure>

--- a/ftw/simplelayout/permissions.zcml
+++ b/ftw/simplelayout/permissions.zcml
@@ -7,4 +7,9 @@
         title="ftw.simplelayout: Change Layouts"
         />
 
+    <permission
+        id="ftw.simplelayout.HideTitle"
+        title="ftw.simplelayout: Hide title"
+        />
+
 </configure>

--- a/ftw/simplelayout/tests/test_contentpage.py
+++ b/ftw/simplelayout/tests/test_contentpage.py
@@ -1,10 +1,11 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
-from ftw.testbrowser import browsing
 from ftw.simplelayout.testing import SimplelayoutTestCase
-from zope.component import getUtility
+from ftw.testbrowser import browsing
 from plone.dexterity.interfaces import IDexterityFTI
+from zope.component import getUtility
+import transaction
 
 
 class TestTextBlockRendering(SimplelayoutTestCase):
@@ -41,3 +42,24 @@ class TestTextBlockRendering(SimplelayoutTestCase):
         self.assertEqual(
             ['A page'],
             browser.css('.documentFirstHeading').text)
+
+    @browsing
+    def test_allow_and_disallow_changing_show_title_field(self, browser):
+
+        self.page.manage_permission('ftw.simplelayout: Hide title',
+                                    roles=[],
+                                    acquire=0)
+        transaction.commit()
+
+        browser.login().visit(self.page, view='edit')
+        self.assertIsNone(browser.find_form_by_field('Show title'),
+                          'Do not expect the "Show title" field.')
+
+        self.page.manage_permission('ftw.simplelayout: Hide title',
+                                    roles=['Manager'],
+                                    acquire=0)
+        transaction.commit()
+
+        browser.visit(self.page, view='edit')
+        self.assertTrue(browser.find_form_by_field('Show title'),
+                        'Exepct the "Show title" field.')

--- a/ftw/simplelayout/tests/test_contentpage_behavior.py
+++ b/ftw/simplelayout/tests/test_contentpage_behavior.py
@@ -8,7 +8,7 @@ from zope.component import getUtility
 import transaction
 
 
-class TestTextBlockRendering(SimplelayoutTestCase):
+class TestContentPageShowTitleBehavior(SimplelayoutTestCase):
 
     layer = FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
 

--- a/ftw/simplelayout/upgrades/20160914172633_protect_show_hide_title_field/rolemap.xml
+++ b/ftw/simplelayout/upgrades/20160914172633_protect_show_hide_title_field/rolemap.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0"?>
 <rolemap>
   <permissions>
-    <permission name="ftw.simplelayout: Change Layouts" acquire="False">
-      <role name="Manager" />
-      <role name="Site Administrator"/>
-    </permission>
     <permission name="ftw.simplelayout: Hide title" acquire="False">
       <role name="Manager" />
       <role name="Site Administrator"/>

--- a/ftw/simplelayout/upgrades/20160914172633_protect_show_hide_title_field/upgrade.py
+++ b/ftw/simplelayout/upgrades/20160914172633_protect_show_hide_title_field/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ProtectShowHideTitleField(UpgradeStep):
+    """Protect show/hide title field.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
I thought calling the permission this way makes more sense, since we are protecting it from getting hidden :-)