### PR TITLE
Support Chameleon caching.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Support Chameleon caching. [jone]
 
 
 1.10.0 (2016-09-30)

--- a/ftw/simplelayout/browser/ajax/add.py
+++ b/ftw/simplelayout/browser/ajax/add.py
@@ -20,6 +20,8 @@ class AddViewTraverser(object):
     adapts(ISimplelayout, Interface)
     implements(ITraversable)
 
+    template = ViewPageTemplateFile('templates/add.pt')
+
     def __init__(self, context, request):
         self.context = context
         self.request = request
@@ -32,8 +34,8 @@ class AddViewTraverser(object):
 
             if add_view is not None:
                 add_view.__name__ = ti.factory
-                template = ViewPageTemplateFile('templates/add.pt')
-                add_view.index = BoundPageTemplate(template, add_view)
+                add_view.index = BoundPageTemplate(self.template.im_func,
+                                                   add_view)
                 return add_view.__of__(self.context)
 
         raise TraversalError(self.context, name)

--- a/ftw/simplelayout/contenttypes/browser/filelistingblock.py
+++ b/ftw/simplelayout/contenttypes/browser/filelistingblock.py
@@ -12,6 +12,8 @@ class FileListingBlockView(BaseBlock):
     """ListingBlock default view"""
 
     template = ViewPageTemplateFile('templates/listingblock.pt')
+    table_template = ViewPageTemplateFile(
+        'templates/ftw.table.custom.template.pt')
 
     def get_table_contents(self):
         catalog = getToolByName(self.context, 'portal_catalog')
@@ -45,15 +47,13 @@ class FileListingBlockView(BaseBlock):
         # The id value is moved to a css klass.
         # Reason: It's no allowed to have an id more than once (In case we
         # have more than one Listingblock on one contentpage)
-        template = ViewPageTemplateFile(
-            'templates/ftw.table.custom.template.pt')
         generator = queryUtility(ITableGenerator, 'ftw.tablegenerator')
         return generator.generate(
             self.get_table_contents(),
             list(self._filtered_columns()),
             sortable=False,
             css_mapping={'table': 'listing nosort'},
-            template=template,
+            template=self.table_template,
             options={'table_summary': self.context.Title()},
             selected=(self._build_query['sort_on'],
                       self._build_query['sort_order']))


### PR DESCRIPTION
By not instantiating page template objects in methods but in class definition scope we give Chameleon a chance to cache the compile template, speeding up everything.