### PR TITLE
Auto resize youtube-videoblocks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.11.1 (unreleased)
 -------------------
 
+- Make youtube-videoblocks auto-resize to the max space available.
+  [raphael-s]
+
 - Fix SCSS linting errors
 
     - This requires ftw.theming>=1.7.0

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -507,6 +507,11 @@ ul[class^="sl-toolbar"] {
   overflow: hidden;
 }
 
+// Prevent FOUC when manually setting the video dimensions
+.sl-youtube-video {
+  visibility: hidden;
+}
+
 @include keyframes(fade) {
   0%   { background-color: transparent; }
   50%   { background-color: #fff3a5; }

--- a/ftw/simplelayout/browser/resources/videoblock.js
+++ b/ftw/simplelayout/browser/resources/videoblock.js
@@ -2,6 +2,29 @@
 
   "use strict";
 
+  // Return function that will be only called during a free painting loop
+  function throttle(func) { return function() { window.requestAnimationFrame(func); }; }
+
+  $(window).on("resize", throttle(resizeAll));
+
+  var ratios = {};
+
+  function resizeAll() { $.map($(".sl-youtube-video"), resizeYoutubePlayer); }
+
+  function onPlayerReady(player) {
+    var iframe = player.target.a;
+
+    ratios[iframe.id] = ratios[iframe.id] || iframe.height/iframe.width;
+
+    iframe.width = "100%";
+    resizeYoutubePlayer(iframe);
+    iframe.style.visibility = "visible";
+  };
+
+  function resizeYoutubePlayer(iframe) {
+    iframe.height = iframe.offsetWidth * ratios[iframe.id];
+  }
+
   $(function() {
 
     var youtubePlayer = {
@@ -18,7 +41,8 @@
             controls: 1,
             rel: 0,
             showInfo: 0
-          }
+          },
+          events: { "onReady": onPlayerReady }
         };
 
         var options = $.extend(defaults, config);
@@ -48,9 +72,7 @@
     };
 
 
-    $(document).on("onBeforeClose", ".overlay", function() {
-      initializeYoutubeApi();
-    });
+    $(document).on("onBeforeClose", ".overlay", initializeYoutubeApi);
 
     initializeYoutubeApi();
 

--- a/ftw/simplelayout/contenttypes/browser/videoblock.py
+++ b/ftw/simplelayout/contenttypes/browser/videoblock.py
@@ -31,8 +31,7 @@ class VideoBlockView(BaseBlock):
         return 'uuid_{0}'.format(IUUID(self.context))
 
     def youtube_config(self):
-        config = {'videoId': self.get_video_id(),
-                  'width': '100%'}
+        config = {'videoId': self.get_video_id()}
 
         return json.dumps(config)
 


### PR DESCRIPTION
This makes videoblocks containing youtube video automatically resize to the available space given by their parent element without changing the width/height ratio.
This way there are no longer any black bars on the side of the block when the available space is bigger than the video itself. 

