### PR TITLE
 Implement a inner_edit.json view, which allows us to edit an item in a folderish block.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -264,11 +264,12 @@ Global Simplelayout configuration
 Create new Block representations
 --------------------------------
 
-Directly edit items in a folderish Block
+Directly edit items in a folderish block
 ----------------------------------------
 
 For this purpose you can place a link in the rendered block.
-Assume you want to edit a file in a ListingBlock you need a link, which is pointing to `./sl-ajax-inner-edit-view`, has the css class `inneredit` and a data attribute named `uid` containing the uid of the content.
+Assume you want to edit a file in a listing block: you need a link, which is pointing to ``./sl-ajax-inner-edit-view``,
+has the css class ``inneredit`` and a data attribute named ``uid`` containing the uid of the content.
 
 .. code-block:: xml
 
@@ -277,7 +278,7 @@ Assume you want to edit a file in a ListingBlock you need a link, which is point
        tal:attributes="data-uid file_object/UID">EDIT</a>
 
 
-After editing the content the view automatically reloads the block.
+After editing the content, the view automatically reloads the block.
 
 
 Run custom JS code

--- a/README.rst
+++ b/README.rst
@@ -264,6 +264,21 @@ Global Simplelayout configuration
 Create new Block representations
 --------------------------------
 
+Directly edit items in a folderish Block
+----------------------------------------
+
+For this purpose you can place a link in the rendered block.
+Assume you want to edit a file in a ListingBlock you need a link, which is pointing to `./sl-ajax-inner-edit-view`, has the css class `inneredit` and a data attribute named `uid` containing the uid of the content.
+
+.. code-block:: xml
+
+    <a href="./sl-ajax-inner-edit-view"
+       class="inneredit"
+       tal:attributes="data-uid file_object/UID">EDIT</a>
+
+
+After editing the content the view automatically reloads the block.
+
 
 Run custom JS code
 ==================

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,11 @@ Changelog
 1.11.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Implement a inner_edit.json view, which allows us to edit an item in a
+  folderish block. For example edit a file directly in a FilelistingBlock.
+  This view works almost like the block edit view, the difference is, that
+  the inner_edit.json view returns the rendered html of its parent (the Block).
+  [mathias.leimgruber]
 
 
 1.11.1 (2016-10-13)

--- a/ftw/simplelayout/browser/ajax/configure.zcml
+++ b/ftw/simplelayout/browser/ajax/configure.zcml
@@ -38,6 +38,13 @@
 
     <browser:page
         for="*"
+        name="sl-ajax-inner-edit-view"
+        class=".edit_block.InnerEditRedirector"
+        permission="cmf.ModifyPortalContent"
+        />
+
+    <browser:page
+        for="*"
         name="sl-ajax-upload-block-view"
         class=".upload.UploadForm"
         permission="cmf.ModifyPortalContent"
@@ -51,5 +58,11 @@
         permission="cmf.ModifyPortalContent"
         />
 
+    <browser:page
+        for="*"
+        name="inner_edit.json"
+        class=".edit_block.InnerEditForm"
+        permission="cmf.ModifyPortalContent"
+        />
 
 </configure>

--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -251,6 +251,18 @@
       });
     });
 
+    $(global.document).on("click", ".sl-block .inneredit", function(event) {
+      event.preventDefault();
+      var block = $(this).parents(".sl-block").data().object;
+      editOverlay.load($(this).attr("href"), {"data": JSON.stringify({ "uid": $(this).data('uid') })});
+      editOverlay.onSubmit(function(data) {
+        block.content(data.content);
+        initializeColorbox();
+        this.close();
+      });
+    });
+
+
     $(global.document).on("click", ".sl-block .redirect", function(event) {
       event.preventDefault();
       var block = $(this).parents(".sl-block").data().object;

--- a/ftw/simplelayout/tests/sample_types.py
+++ b/ftw/simplelayout/tests/sample_types.py
@@ -43,9 +43,17 @@ class ISampleDXBlock(Interface):
     pass
 
 
+class ISampleDXFolderishBlock(Interface):
+    pass
+
+
 class SampleBlock(Item):
     # In Plone 5 the ISimplelayoutBlock marker behavior does not work in tests.
     implements(ISampleDXBlock, ISimplelayoutBlock)
+
+
+class SampleFolderishBlock(Container):
+    implements(ISampleDXFolderishBlock, ISimplelayoutBlock)
 
 
 class ISampleSimplelayoutContainer(Interface):
@@ -68,8 +76,14 @@ class SampleBlockBuilder(DexterityBuilder):
     portal_type = 'SampleBlock'
 
 
+class SampleFolderishBlockBuilder(DexterityBuilder):
+    portal_type = 'SampleFolderishBlock'
+
+
 registry.builder_registry.register('sample block', SampleBlockBuilder)
 registry.builder_registry.register('sample container', SampleContainerBuilder)
+registry.builder_registry.register('sample folderish block',
+                                   SampleFolderishBlockBuilder)
 
 
 # Setup
@@ -102,9 +116,23 @@ def setup_ftis(portal):
 
     types_tool._setObject('SampleBlock', fti)
 
+    # Simplelayout folderish Block
+    fti = DexterityFTI('SampleFolderishBlock')
+    fti.schema = 'ftw.simplelayout.tests.sample_types.ISampleDXBlockSchema'
+    fti.klass = 'ftw.simplelayout.tests.sample_types.SampleFolderishBlock'
+    fti.default_view = 'block_view'
+    fti.global_allow = False
+    fti.behaviors = (
+        'ftw.simplelayout.interfaces.ISimplelayoutBlock',
+        'plone.app.lockingbehavior.behaviors.ILocking',
+        'plone.app.content.interfaces.INameFromTitle',)
+
+    types_tool._setObject('SampleFolderishBlock', fti)
+    folderishblock_fti = types_tool.get('SampleFolderishBlock')
+    folderishblock_fti.allowed_content_types = ('SampleContainer', )
+
     contentpage_fti = types_tool.get('SampleContainer')
-    contentpage_fti.allowed_content_types = (
-        'SampleBlock', )
+    contentpage_fti.allowed_content_types = ('SampleBlock', )
 
 
 def setup_views():
@@ -116,6 +144,11 @@ def setup_views():
 
     provideAdapter(SampleBlockView,
                    adapts=(ISampleDXBlock, Interface),
+                   provides=IBrowserView,
+                   name='block_view')
+
+    provideAdapter(SampleBlockView,
+                   adapts=(ISampleDXFolderishBlock, Interface),
                    provides=IBrowserView,
                    name='block_view')
 

--- a/ftw/simplelayout/tests/test_inner_edit_block.py
+++ b/ftw/simplelayout/tests/test_inner_edit_block.py
@@ -1,0 +1,118 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+from ftw.simplelayout.testing import SimplelayoutTestCase
+from ftw.testbrowser import browsing
+from plone import api
+from plone.uuid.interfaces import IUUID
+from zExceptions import BadRequest
+import json
+
+
+class TestInnerEdit(SimplelayoutTestCase):
+
+    layer = FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.setup_sample_ftis(self.layer['portal'])
+        self.setup_block_views()
+
+        types_tool = api.portal.get_tool('portal_types')
+        contentpage_fti = types_tool.get('SampleContainer')
+        contentpage_fti.allowed_content_types = ('SampleFolderishBlock', )
+
+        self.page = create(Builder('sample container'))
+        self.folderishblock = create(Builder('sample folderish block'))
+
+        self.innercontent = create(Builder('sample container')
+                                   .within(self.folderishblock))
+
+    def get_payload(self, content):
+        uid = IUUID(content)
+        return {'data': json.dumps({'uid': uid})}
+
+    @browsing
+    def test_redirector_redirects_to_edit_view(self, browser):
+        browser.login()
+
+        with self.assertRaises(BadRequest):
+            browser.visit(self.page,
+                          view='sl-ajax-inner-edit-view',
+                          data={})
+
+            browser.visit(self.page,
+                          view='sl-ajax-inner-edit-view',
+                          data={'data': json.dumps({'block': 'DUMMY'})})
+
+        browser.visit(self.page,
+                      view='sl-ajax-inner-edit-view',
+                      data=self.get_payload(self.innercontent))
+
+        self.assertEquals(
+            '{0}/inner_edit.json'.format(self.innercontent.absolute_url()),
+            browser.url)
+
+    @browsing
+    def test_edit_a_block_returns_json(self, browser):
+        browser.login().visit(self.innercontent, view='inner_edit.json')
+
+        self.assertEquals(json.loads(json.dumps(browser.contents)),
+                          browser.contents)
+
+    @browsing
+    def test_edit_an_item_in_block_returns_content_and_proceed(self, browser):
+        browser.login().visit(self.innercontent, view='inner_edit.json')
+        response = json.loads(browser.contents)
+
+        self.assertIn('content',
+                      response,
+                      'Response does not contain content.')
+
+        self.assertIn('proceed',
+                      response,
+                      'Response does not contain proceed.')
+
+    @browsing
+    def test_inner_edit_content_contains_a_form(self, browser):
+        browser.login().visit(self.innercontent, view='inner_edit.json')
+        response = browser.json
+        browser.open_html(response['content'])
+
+        self.assertTrue(browser.css('form'), 'No form found in content.')
+
+    @browsing
+    def test_inner_edit_proceed_is_false(self, browser):
+        browser.login().visit(self.innercontent, view='inner_edit.json')
+        response = browser.json
+
+        self.assertFalse(response['proceed'], 'Proceed should be false.')
+
+    @browsing
+    def test_inner_edit_returns_the_block_content(self, browser):
+        browser.login().visit(self.innercontent, view='inner_edit.json')
+        response = browser.json
+
+        browser.open_html(response['content'])
+        browser.fill({'Title': u'This is a title'})
+        browser.find_button_by_label('Save').click()
+
+        response = browser.json
+        browser.open_html(response['content'])
+        self.assertFalse(browser.css('form'), 'No form expected.')
+        self.assertEquals('OK',
+                          browser.contents)
+
+    @browsing
+    def test_submit_inner_block_traverser_proceed_returns_true(self, browser):
+        browser.login().visit(self.innercontent, view='inner_edit.json')
+        response = browser.json
+
+        browser.open_html(response['content'])
+        browser.fill({'Title': u'This is a title'})
+        browser.find_button_by_label('Save').click()
+
+        response = browser.json
+        browser.open_html(response['content'])
+        self.assertTrue(
+            response['proceed'],
+            'Proceed should be true after submitting the form.')

--- a/ftw/simplelayout/tests/test_simplelayout_view.py
+++ b/ftw/simplelayout/tests/test_simplelayout_view.py
@@ -381,7 +381,7 @@ class TestSimplelayoutView(SimplelayoutTestCase):
 
         view = self.container.restrictedTraverse('@@simplelayout-view')
         self.assertEqual(
-            ['SampleBlock'],
+            ['SampleBlock', 'SampleFolderishBlock'],
             view.addable_block_types()
         )
 


### PR DESCRIPTION
For example edit a file directly in a FilelistingBlock.
This view works almost like the block edit view, the difference is, that
the inner_edit.json view returns the rendered html of its parent (the Block).

FYI:
I'm gonna use this feature in the ftw.sliderblock first. 