### PR TITLE
Disable inline validation of the Plone forms in the overlay.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.12.3 (unreleased)
 -------------------
 
+- Disable inline validation of the Plone forms in the overlay.
+  [mbaechtold]
+
 - Hide toolbox on small devices.
   [Kevin Bieri]
 

--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -2,6 +2,11 @@
 
   "use strict";
 
+  // Disable inline validation of the Plone forms in the overlay.
+  $(document).on('onLoad OverlayContentReloaded', '.overlay', function(){
+    $('.z3cformInlineValidation').removeClass('z3cformInlineValidation');
+  });
+
   function markLinks(element) {
     if (typeof global.external_links_open_new_window === "string" && global.external_links_open_new_window.toLowerCase() === "true") {
       var url = window.location.protocol + "//" + window.location.host;


### PR DESCRIPTION
The main reason for this is the Plone file widget which causes some browsers to trigger the validation when the user wants to replace the file. The validation is triggered when the user clicks the button to select a file from the filesystem and he has to click it a second time for the file selector to open.

![screenrecording](https://cloud.githubusercontent.com/assets/28220/20627173/a727f82e-b31e-11e6-9afd-ac955941f945.gif)
