### PR TITLE
Fix a bug in gallery block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.12.3 (unreleased)
 -------------------
 
+- Prevent gallery block from failing when it contains image objects having
+  umlauts in their title.
+  [mbaechtold]
+
 - Disable inline validation of the Plone forms in the overlay.
   [mbaechtold]
 

--- a/ftw/simplelayout/contenttypes/browser/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/browser/galleryblock.py
@@ -3,6 +3,7 @@ from ftw.simplelayout import _
 from ftw.simplelayout.browser.blocks.base import BaseBlock
 from plone.app.imaging.utils import getAllowedSizes
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.i18n import translate
 
@@ -35,7 +36,7 @@ class GalleryBlockView(BaseBlock):
         return bool(permission)
 
     def generate_image_alttext(self, img):
-        title = img.title_or_id().decode('utf-8')
+        title = safe_unicode(img.title_or_id())
         return translate(_(u'image_link_alttext',
                            default=u'${title}, enlarged picture.',
                            mapping={'title': title}),

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -372,4 +372,27 @@ class TestGalleryBlock(TestCase):
 
         self.assertEqual(img_title_list, ['b_img', 'c_img', 'a_img'])
 
+    @browsing
+    def test_image_title_with_umlaut(self, browser):
+        """
+        This test makes sure that gallery block does not fail when
+        it contains image objects having umlauts in their title.
+        """
+        gallery = create(Builder('sl galleryblock')
+                         .titled('My Gallery Block')
+                         .within(self.page))
+        create(Builder('image')
+               .titled(u'T\xe4st')
+               .with_dummy_content()
+               .within(gallery))
 
+        browser.login()
+        browser.open(self.page)
+        self.assertEqual(
+            u'T\xe4st',
+            browser.css('.ftw-simplelayout-galleryblock .sl-block-content a').first.attrib['title']
+        )
+        self.assertEqual(
+            u'T\xe4st, enlarged picture.',
+            browser.css('.ftw-simplelayout-galleryblock .sl-block-content a img').first.attrib['alt']
+        )


### PR DESCRIPTION
The bug caused the gallery block to fail (not able to render its content) when the block contained image objects having umlauts in their title.