### PR TITLE
cleanup reference widget dependencies.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.13.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Move ``ftw.referencewidget`` dependency to ``contenttypes`` extras. [jone]
+
+- Drop ``plone.formwidget.contenttree`` dependency. [jone]
 
 
 1.13.0 (2016-12-06)

--- a/ftw/simplelayout/contenttypes/profiles/default/metadata.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default/metadata.xml
@@ -4,7 +4,6 @@
     <dependency>profile-plone.app.dexterity:default</dependency>
     <dependency>profile-collective.js.jqueryui:default</dependency>
     <dependency>profile-plone.app.relationfield:default</dependency>
-    <dependency>profile-plone.formwidget.contenttree:default</dependency>
     <dependency>profile-ftw.simplelayout:lib</dependency>
     <dependency>profile-collective.quickupload:default</dependency>
     <dependency>profile-ftw.colorbox:default</dependency>

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ extras_require = {
         'plone.behavior',
         'plone.dexterity',
         'plone.directives.form',
-        'plone.formwidget.contenttree',
+        'ftw.referencewidget',
     ],
     'mapblock': [
         'collective.geo.bundle [dexterity]',
@@ -97,7 +97,6 @@ setup(name='ftw.simplelayout',
           'Zope2',
           'z3c.form>=3.2.9',
           'Plone',
-          'ftw.referencewidget',
           'ftw.theming>=1.7.0',
           ],
 


### PR DESCRIPTION
- Move ``ftw.referencewidget`` dependency to ``contenttypes`` extras, since it is only used for the content types subpackage.

- Remove ``plone.formwidget.contenttree`` dependency, as it is not used at all because it was replaced with ``ftw.referencewidget``.

// cc @tschanzt 