### PR TITLE
Log traceback too when a block cannot be rendered.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Log traceback too when a block cannot be rendered. [jone]
 
 
 1.14.0 (2017-01-04)

--- a/ftw/simplelayout/browser/provider.py
+++ b/ftw/simplelayout/browser/provider.py
@@ -138,10 +138,8 @@ class BaseSimplelayoutExpression(object):
         except ConflictError:
             raise
         except Exception, exc:
+            LOG.exception(exc)
             html = self.fallbackview()
-            LOG.error('Could not render block: {}: {}'.format(
-                exc.__class__.__name__,
-                str(exc)))
 
         return html
 


### PR DESCRIPTION
When a block could not be rendered, the log / console did only contain
"Could not render block" and the error message, but not the traceback.

By using LOG.exception the full traceback is logged too.