### PR TITLE
provide support for anchors within the same page.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,13 @@ Changelog
 1.14.1 (unreleased)
 -------------------
 
+- TinyMCE: Disable "anchor"-Tab when creating a link. [jone]
+
+- TinyMCE: configure content page to contain anchors. [jone]
+
+- Change primary field of text block from "image" to "text" field
+  in order to support anchors. [jone]
+
 - Log traceback too when a block cannot be rendered. [jone]
 
 

--- a/ftw/simplelayout/browser/anchors.py
+++ b/ftw/simplelayout/browser/anchors.py
@@ -1,0 +1,18 @@
+from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from Products.Five.browser import BrowserView
+from Products.TinyMCE.browser.interfaces.anchors import IAnchorView
+from zope.interface import implements
+
+
+class BlockAnchorsView(BrowserView):
+    implements(IAnchorView)
+
+    def listAnchorNames(self, *args, **kwargs):
+        anchors = []
+        query = {'object_provides': ISimplelayoutBlock.__identifier__}
+
+        for block in self.context.listFolderContents(contentFilter=query):
+            view = block.restrictedTraverse('content_anchors')
+            anchors.extend(view.listAnchorNames(*args, **kwargs))
+
+        return anchors

--- a/ftw/simplelayout/browser/configure.zcml
+++ b/ftw/simplelayout/browser/configure.zcml
@@ -58,4 +58,11 @@
              *"
         />
 
+    <browser:page
+        for="ftw.simplelayout.interfaces.ISimplelayout"
+        name="content_anchors"
+        class=".anchors.BlockAnchorsView"
+        permission="zope2.View"
+        />
+
 </configure>

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -528,3 +528,15 @@ ul[class^="sl-toolbar"] {
   50%   { background-color: #fff3a5; }
   100% { background-color: transparent; }
 }
+
+
+/*
+   TinyMCE: Disable "anchor"-tab in link dialog because this dialog only support
+   anchors within the same TinyMCE instance, but we need to be able to select
+   anchors from other blocks.
+   In order to select anchors, select the page in the regular "internal" tab,
+   and then select the anchor.
+*/
+#plonebrowser #anchor_link {
+  display: none;
+}

--- a/ftw/simplelayout/contenttypes/contents/textblock.py
+++ b/ftw/simplelayout/contenttypes/contents/textblock.py
@@ -37,12 +37,12 @@ class ITextBlockSchema(form.Schema):
         required=False)
 
     dexteritytextindexer.searchable('text')
+    form.primary('text')
     text = RichText(
         title=_(u'label_text', default=u'Text'),
         required=False,
         allowed_mime_types=('text/html',))
 
-    form.primary('image')
     image = NamedBlobImage(
         title=_(u'label_image', default=u'Image'),
         required=False)

--- a/ftw/simplelayout/contenttypes/profiles/default/tinymce.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default/tinymce.xml
@@ -16,5 +16,9 @@
             <element value="ftw.simplelayout.GalleryBlock"/>
         </containsobjects>
 
+        <containsanchors purge="False">
+            <element value="ftw.simplelayout.ContentPage"/>
+        </containsanchors>
+
     </resourcetypes>
 </object>

--- a/ftw/simplelayout/contenttypes/profiles/uninstall/tinymce.xml
+++ b/ftw/simplelayout/contenttypes/profiles/uninstall/tinymce.xml
@@ -16,5 +16,9 @@
             <element value="ftw.simplelayout.GalleryBlock" remove="True"/>
         </containsobjects>
 
+        <containsanchors purge="False">
+            <element value="ftw.simplelayout.ContentPage" remove="True"/>
+        </containsanchors>
+
     </resourcetypes>
 </object>

--- a/ftw/simplelayout/contenttypes/upgrades/20170106151929_configure_page_to_contain_anchors/tinymce.xml
+++ b/ftw/simplelayout/contenttypes/upgrades/20170106151929_configure_page_to_contain_anchors/tinymce.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object>
+    <resourcetypes>
+
+        <containsanchors purge="False">
+            <element value="ftw.simplelayout.ContentPage"/>
+        </containsanchors>
+
+    </resourcetypes>
+</object>

--- a/ftw/simplelayout/contenttypes/upgrades/20170106151929_configure_page_to_contain_anchors/upgrade.py
+++ b/ftw/simplelayout/contenttypes/upgrades/20170106151929_configure_page_to_contain_anchors/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class ConfigurePageToContainAnchors(UpgradeStep):
+    """Configure page to contain anchors.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()

--- a/ftw/simplelayout/tests/test_anchors.py
+++ b/ftw/simplelayout/tests/test_anchors.py
@@ -1,0 +1,32 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
+from plone.app.textfield.value import RichTextValue
+from unittest2 import TestCase
+
+
+class TestPageAnchors(TestCase):
+    layer = FTW_SIMPLELAYOUT_CONTENT_TESTING
+
+    def test_anchors(self):
+        """
+        This test makes sure that `ContentPageAnchorView` is able
+        to extract the anchors form the text blocks of a content page.
+        """
+
+        contentpage = create(Builder('sl content page').titled(u'The Page'))
+        create(Builder('sl textblock')
+               .within(contentpage)
+               .having(text=RichTextValue(
+                   u'<p>Lorem <a name="anchor-textblock1"></a> '
+                   u'ipsum dolor sit amet.</p>')))
+        create(Builder('sl textblock')
+               .within(contentpage)
+               .having(text=RichTextValue(
+                   u'<p>Lorem <a name="anchor-textblock2"></a> '
+                   u'ipsum dolor sit amet.</p>')))
+
+        view = contentpage.restrictedTraverse('content_anchors')
+        anchor_names = view.listAnchorNames()
+        self.assertEqual(['anchor-textblock1', 'anchor-textblock2'],
+                         anchor_names)


### PR DESCRIPTION
In order to support anchors in the same content page, but over multiple
blocks, these changes are necessary:

- Enable anchors on content pages.
- Let the content page provide the anchors of it's text blocks.
- Change the priamry-field of text-blocks from "image" to "text" in
  order to be able to extract the anchors from the textfield.
- Disable the "anchors"-tab in the link dialog of TinyMCE, because it
  does only list local anchors of the same textfield, but when using
  simplelayout it is more confusing because the anchors of the other
  textblocks on the same page are missing.

In order to set an anchor, select the current page in the "internal" tab (by going up in the path bar), and then select the anchor at the right hand.

![bildschirmfoto 2017-01-06 um 15 32 16](https://cloud.githubusercontent.com/assets/7469/21720778/5ba2aa3e-d425-11e6-9241-6d9a35ea5acf.png)
