### PR TITLE
Improve caption of the textblock's colorbox.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.15.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Extend the textblock with the "data-caption" attribute which can hold
+  the caption rendered in the colorbox (requires "ftw.colorbox" 1.3).
+  [mbaechtold]
 
 
 1.15.1 (2017-01-17)

--- a/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
@@ -18,6 +18,7 @@
             <a tal:omit-tag="not: image/link_url"
                tal:attributes="href image/link_url;
                                title image/link_title;
+                               data-caption context/image_caption;
                                class image/link_css_classes">
                 <img tal:replace="structure image/image_tag" />
             </a>

--- a/ftw/simplelayout/tests/test_textblock_view.py
+++ b/ftw/simplelayout/tests/test_textblock_view.py
@@ -254,3 +254,25 @@ class TestTextBlockRendering(TestCase):
         browser.login().visit(self.page)
         self.assertTrue(
             browser.css('.sl-block.titleOnly'), 'Expext title only class.')
+
+    @browsing
+    def test_data_caption_holds_caption_of_image(self, browser):
+        """
+        This test makes sure that there is an attribute "data-caption"
+        on the link opening the colorbox and that it holds the caption
+        defined on the textblock.
+        """
+        block = create(Builder('sl textblock')
+                       .within(self.page)
+                       .titled('TextBlock title')
+                       .having(image_caption=u'The caption')
+                       .having(text=RichTextValue('The text'))
+                       .having(image=NamedBlobImage(data=self.image.read(),
+                                                    filename=u'test.gif'))
+                       .having(open_image_in_overlay=True,))
+
+        browser.login().visit(block, view='@@block_view')
+        self.assertEqual(
+            u'The caption',
+            browser.css('a.colorboxLink').first.attrib['data-caption']
+        )


### PR DESCRIPTION
🚧 Please merge https://github.com/4teamwork/ftw.colorbox/pull/11 and release `ftw.colorbox` 1.3 first.

Extend the textblock with the "data-caption" attribute which can hold the caption rendered in the colorbox (requires "ftw.colorbox" 1.3).
