### PR TITLE
Fix map block not showing the Google maps.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.16.1 (unreleased)
 -------------------
 
+- Fix map block not showing the Google maps.
+  [mbaechtold]
+
 - Use browserify as javascript bundler
 
   - Update tests using karma

--- a/ftw/simplelayout/mapblock/browser/templates/mapblock.pt
+++ b/ftw/simplelayout/mapblock/browser/templates/mapblock.pt
@@ -7,7 +7,7 @@
   <div id="map" class="blockwidget-cgmap"
        tal:attributes="id mapid;
           style context/@@collectivegeo-macros/map_inline_css;
-          data-googlejs string:${geosettings/google_maps_js};
+          data-googlejs python:geosettings.google_maps_js;
           data-cgeolatitude map_defaults/latitude|nothing;
           data-cgeolongitude map_defaults/longitude|nothing;
           data-cgeozoom map_defaults/zoom|nothing;


### PR DESCRIPTION
The problem is a change in the behavior how string expressions are evaluated in TAL (possibly due to "ftw.chameleon":

```
obj.some_url = 'http://bla.com/blubber?key=value&key2=value'

string: ${obj/some_url}
> http://bla.com/blubber?key=value&amp;key2=value

python: obj.some_url
> http://bla.com/blubber?key=value&key2=value
```