### PR TITLE
Restore slot defaults when removing last layout.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.17.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Restore slot defaults when removing last layout. [jone]
 
 
 1.17.0 (2017-01-26)

--- a/ftw/simplelayout/configuration.py
+++ b/ftw/simplelayout/configuration.py
@@ -149,9 +149,16 @@ class PageConfiguration(object):
 
     def load(self):
         annotations = IAnnotations(self.context)
-        return deepcopy(annotations.setdefault(
+        default_state = deepcopy(self._default_page_config())
+        page_state = deepcopy(annotations.setdefault(
             SL_ANNOTATION_KEY,
-            make_resursive_persistent(self._default_page_config())))
+            make_resursive_persistent(default_state)))
+
+        for slotname in default_state:
+            if not page_state.get(slotname):
+                page_state[slotname] = default_state[slotname]
+
+        return page_state
 
     def check_permission(self, new_state):
         if api.user.has_permission('ftw.simplelayout: Change Layouts',


### PR DESCRIPTION
When removing the last layout from a slot, we want the slot to be restored to the defaults, whatever that is.

It should not destroy states of other slots though.

/cc @mbaechtold 