### PR TITLE
Fix UnboundLocalError in the simplelayout portlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.18.2 (unreleased)
 -------------------
 
+- Fix UnboundLocalError in the simplelayout portlet. [mbaechtold]
+
 - Make anchor extraction more robust. [mbaechtold]
 
 

--- a/ftw/simplelayout/portlets/portlet.py
+++ b/ftw/simplelayout/portlets/portlet.py
@@ -40,6 +40,7 @@ class Renderer(base.Renderer):
         config = IPageConfiguration(self.context)
         data = config.load()
 
+        portlet_container = []
         if self.manager.__name__ == 'plone.rightcolumn':
             portlet_container = data.get('portletright', [])
         elif self.manager.__name__ == 'plone.leftcolumn':


### PR DESCRIPTION
This might happen if there are other portlet manager, e.g. from `ftw.footer`.

```
ERROR portlets Error while determining renderer availability of portlet ('context' '/ai/platform/verwaltung/ratskanzlei' u'simplelayout-portlet'): local variable 'portlet_container' referenced before assignment
Traceback (most recent call last):
  File "/Users/mbaechtold/.buildout/eggs/plone.portlets-2.2-py2.7.egg/plone/portlets/manager.py", line 117, in _lazyLoadPortlets
    isAvailable = renderer.available
  File "/Users/mbaechtold/.buildout/eggs/ftw.simplelayout-1.17.0-py2.7.egg/ftw/simplelayout/portlets/portlet.py", line 32, in available
    if self.has_blocks():
  File "/Users/mbaechtold/.buildout/eggs/ftw.simplelayout-1.17.0-py2.7.egg/ftw/simplelayout/portlets/portlet.py", line 44, in has_blocks
    if self.manager.__name__ == 'plone.rightcolumn':
UnboundLocalError: local variable 'portlet_container' referenced before assignment
```