### PR TITLE
Prevent plone ajax spinner from being shown.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.17.1 (unreleased)
 -------------------
 
+- Prevent plone ajax spinner from being shown. [Kevin Bieri]
+
 - Restore slot defaults when removing last layout. [jone]
 
 

--- a/ftw/simplelayout/browser/resources/RequestTracker.js
+++ b/ftw/simplelayout/browser/resources/RequestTracker.js
@@ -98,7 +98,7 @@
       Disable kss spinner. In order for this to work, this file must be evaluated after kss-bbb.js.
       As you can see in the lib profile's jsregistry.xml.
     */
-    $document.off("ajaxStart");
+    $.ajaxSetup({ global: false });
 
     $document.on("ajaxSend", function(event, jqxhr, params) { track(params.url); });
     $document.on("ajaxComplete", function(event, jqxhr, params) { untrack(params.url); });


### PR DESCRIPTION
The current approach to get rid of the spinner seems not to work properly.
Trying to unbind the `ajaxStart` event does not work in all cases.

So according to https://api.jquery.com/ajaxStart/,
> If $.ajax() or $.ajaxSetup() is called with the global option set to false, the .ajaxStart() method will not fire.

setting the `global` option to `false` never triggers the `ajaxStart` event.