### PR TITLE
Make MapBlock addable on plone site

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.17.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make MapBlock addable on plone site per default [raphael-s]
 
 
 1.17.1 (2017-02-28)

--- a/ftw/simplelayout/mapblock/profiles/default/types/Plone_Site.xml
+++ b/ftw/simplelayout/mapblock/profiles/default/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.simplelayout.MapBlock" />
+    </property>
+
+</object>

--- a/ftw/simplelayout/mapblock/profiles/uninstall/types/Plone_Site.xml
+++ b/ftw/simplelayout/mapblock/profiles/uninstall/types/Plone_Site.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="Plone Site">
+
+    <property name="allowed_content_types" purge="False">
+        <element value="ftw.simplelayout.MapBlock" remove="True"/>
+    </property>
+
+</object>


### PR DESCRIPTION
When `ftw.simplelyout[mapblock]` is installed the MapBlock can now be added to plone site per default.

We don't want an upgrade step for this because we don't want to change how existing deployments handle the MapBlock.