### PR TITLE
Improve anchor extraction.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.17.3 (unreleased)
 -------------------
 
+- Improve anchor extraction. [mbaechtold]
+
 - Synchronize simplelayout block order to Plone's ordered container. [jone]
 
 - Improve support for hidden blocks introduced in 1.2.1. [mbaechtold]

--- a/ftw/simplelayout/browser/anchors.py
+++ b/ftw/simplelayout/browser/anchors.py
@@ -1,7 +1,14 @@
-from ftw.simplelayout.interfaces import ISimplelayoutBlock
-from Products.Five.browser import BrowserView
 from Products.TinyMCE.browser.interfaces.anchors import IAnchorView
+from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from lxml.html import fromstring
+from plone.app.textfield import IRichText
+from plone.dexterity.utils import iterSchemata
+from Products.Five.browser import BrowserView
 from zope.interface import implements
+from zope.schema import getFieldsInOrder
+
+
+SEARCHPATTERN = "a"
 
 
 class BlockAnchorsView(BrowserView):
@@ -12,7 +19,36 @@ class BlockAnchorsView(BrowserView):
         query = {'object_provides': ISimplelayoutBlock.__identifier__}
 
         for block in self.context.listFolderContents(contentFilter=query):
-            view = block.restrictedTraverse('content_anchors')
-            anchors.extend(view.listAnchorNames(*args, **kwargs))
+            fields = self.get_html_fields(block)
+
+            for field in fields:
+                anchors.extend(
+                    self.extract_anchors(
+                        field.get(block).output
+                    )
+                )
 
         return anchors
+
+    def get_html_fields(self, obj):
+        fields = []
+        for schema in iterSchemata(obj):
+            for name, field in getFieldsInOrder(schema):
+                # Only consider RichText fields.
+                if IRichText.providedBy(field):
+                    fields.append(field)
+
+        # Filter empty fields (i.e. not having a value).
+        fields = filter(lambda field: field.get(obj), fields)
+
+        # Only consider fields containing HTML.
+        fields = filter(lambda field: 'html' in field.output_mime_type, fields)
+
+        return fields
+
+    def extract_anchors(self, text):
+        tree = fromstring(text)
+        return [
+            anchor.get('name') for anchor in tree.findall(SEARCHPATTERN)
+            if "name" in anchor.keys()
+        ]

--- a/ftw/simplelayout/tests/test_anchors.py
+++ b/ftw/simplelayout/tests/test_anchors.py
@@ -30,3 +30,19 @@ class TestPageAnchors(TestCase):
         anchor_names = view.listAnchorNames()
         self.assertEqual(['anchor-textblock1', 'anchor-textblock2'],
                          anchor_names)
+
+    def test_anchors_in_empty_textblock(self):
+        """
+        A textblock without content does not contain anchors. Make sure the anchor
+        extraction does not fail in this case.
+        """
+        contentpage = create(Builder('sl content page').titled(u'The Page'))
+        create(Builder('sl textblock')
+               .within(contentpage)
+               .with_dummy_image())
+        view = contentpage.restrictedTraverse('content_anchors')
+        anchor_names = view.listAnchorNames()
+        self.assertEqual(
+            [],
+            anchor_names
+        )


### PR DESCRIPTION
No longer rely on TinyMCE for the anchor extraction because it contains a bug when an empty value is searched for anchors (see https://github.com/plone/Products.TinyMCE/pull/153).