### PR TITLE
Remove "addable_block_types".

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Make anchor extraction more robust. [mbaechtold]
 
+- Remove unused "addable_block_types" method from simplelayout view. [jone]
+
 
 1.18.1 (2017-03-23)
 -------------------

--- a/ftw/simplelayout/browser/configure.zcml
+++ b/ftw/simplelayout/browser/configure.zcml
@@ -22,7 +22,6 @@
         name="simplelayout-view"
         permission="zope2.View"
         class=".simplelayout.SimplelayoutView"
-        allowed_attributes="addable_block_types"
         />
 
     <browser:page

--- a/ftw/simplelayout/browser/simplelayout.py
+++ b/ftw/simplelayout/browser/simplelayout.py
@@ -1,8 +1,7 @@
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from ftw.simplelayout import utils
 from ftw.simplelayout.interfaces import IContentPageShowTitle
 from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.simplelayout.interfaces import ISimplelayoutView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zExceptions import BadRequest
 from zope.interface import implements
 from zope.publisher.browser import BrowserView
@@ -34,14 +33,6 @@ class SimplelayoutView(BrowserView):
 
     def update_simplelayout_settings(self, settings):
         pass
-
-    def addable_block_types(self):
-        """
-        Returns a list of dotted fti ids.
-
-        Example: ['ftw.simplelayout.TextBlock']
-        """
-        return [block_type.id for block_type in utils.get_block_types()]
 
     def show_title(self):
         try:

--- a/ftw/simplelayout/tests/test_simplelayout_view.py
+++ b/ftw/simplelayout/tests/test_simplelayout_view.py
@@ -375,18 +375,6 @@ class TestSimplelayoutView(SimplelayoutTestCase):
         )
 
     @browsing
-    def test_addable_block_types_view_property(self, browser):
-        create(Builder('sample block')
-               .titled('Block 1')
-               .within(self.container))
-
-        view = self.container.restrictedTraverse('@@simplelayout-view')
-        self.assertEqual(
-            ['SampleBlock', 'SampleFolderishBlock'],
-            view.addable_block_types()
-        )
-
-    @browsing
     def test_canEdit_is_false_if_border_disabled(self, browser):
         browser.login().visit(self.container, data={'disable_border': 1})
         data_attr_value = json.loads(browser.css(


### PR DESCRIPTION
The method `addable_block_types` on the simplelayout view is not in use and is therefore removed.

---

As I am customizing the `simplelayout-view` in my package I wanted to switch from `allowed_attributes` to `allowed_interface` so that I can inherit the configuration and do not need to update on new attributes in the future.

But I then came to the impression that the method `addable_block_types` was not used at all; the toolbar seems to work fine without.

@maethu please verify and confirm that this method is actually not used before merging this pull request!