### PR TITLE
testing: remove duplicate ZCML loading.

### DIFF
--- a/ftw/simplelayout/testing.py
+++ b/ftw/simplelayout/testing.py
@@ -52,9 +52,6 @@ class FtwSimplelayoutLayer(PloneSandboxLayer):
             '</configure>',
             context=configurationContext)
 
-        import ftw.simplelayout
-        xmlconfig.file('configure.zcml', ftw.simplelayout,
-                       context=configurationContext)
         z2.installProduct(app, 'ftw.simplelayout')
 
     def setUpPloneSite(self, portal):


### PR DESCRIPTION
This is not necessary since _everything_ is loaded by `z3c.autoinclude` a statement above.