### PR TITLE
Make anchor extraction more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.18.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make anchor extraction more robust. [mbaechtold]
 
 
 1.18.1 (2017-03-23)

--- a/ftw/simplelayout/browser/anchors.py
+++ b/ftw/simplelayout/browser/anchors.py
@@ -47,6 +47,8 @@ class BlockAnchorsView(BrowserView):
         return fields
 
     def extract_anchors(self, text):
+        if not text:
+            return []
         tree = fromstring(text)
         return [
             anchor.get('name') for anchor in tree.findall(SEARCHPATTERN)

--- a/ftw/simplelayout/tests/test_anchors.py
+++ b/ftw/simplelayout/tests/test_anchors.py
@@ -46,3 +46,19 @@ class TestPageAnchors(TestCase):
             [],
             anchor_names
         )
+
+    def test_anchors_with_empty_strings(self):
+        """
+        A rich text value containing a zero-length string does not contain anchors.
+        Make sure the anchor extraction does not fail in this case.
+        """
+        contentpage = create(Builder('sl content page').titled(u'The Page'))
+        create(Builder('sl textblock')
+               .within(contentpage)
+               .having(text=RichTextValue(u'')))
+        view = contentpage.restrictedTraverse('content_anchors')
+        anchor_names = view.listAnchorNames()
+        self.assertEqual(
+            [],
+            anchor_names
+        )


### PR DESCRIPTION
lxml raises a XMLSyntaxError if an empty string is passed.