### PR TITLE
Disable kss spinner.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.18.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Disable kss spinner. [Kevin Bieri]
 
 
 1.18.2 (2017-03-30)

--- a/ftw/simplelayout/browser/resources/RequestTracker.js
+++ b/ftw/simplelayout/browser/resources/RequestTracker.js
@@ -97,11 +97,19 @@
     /*
       Disable kss spinner. In order for this to work, this file must be evaluated after kss-bbb.js.
       As you can see in the lib profile's jsregistry.xml.
-    */
-    $.ajaxSetup({ global: false });
 
-    $document.on("ajaxSend", function(event, jqxhr, params) { track(params.url); });
-    $document.on("ajaxComplete", function(event, jqxhr, params) { untrack(params.url); });
+      The `ajaxStart` and `ajaxStop` event is used in kss-bbb.js to toggle the spinner.
+      In simplelayout we have our own spinner so by unbinding these two events the spinner
+      is no longer shown.
+      So for every XHR request that has been started. it'll be tracked by the RequestTracker to
+      handle the spinner.
+    */
+    $(function() {
+      $document.unbind("ajaxStart");
+      $document.unbind("ajaxStop");
+      $document.on("ajaxSend", function(event, jqxhr, params) { track(params.url); });
+      $document.on("ajaxComplete", function(event, jqxhr, params) { untrack(params.url); });
+    })
 
     return Object.freeze({
       track: track,


### PR DESCRIPTION
Setting ajaxSetup.global to `false` is disabling every ajax event.
As described here https://api.jquery.com/ajaxSend/ the `ajaxSend` event is canceled as well.
So the request tracker was not working since https://github.com/4teamwork/ftw.simplelayout/pull/427 because all ajax events has been canceled.

First step is to remove the ajaxSetup.global setting to `false`.

Second step is to unbind the ajax event listeners from the kss.js
Two things are important here:
1. The RequestTracker.js has to come after the kss so that the listener is unbind properly
2. The unbind function has to be wrapped in a jQuery.ready callback because the kss.js is doing so as well

Third step is to bind our own ajax events to track all requests relevant for showing the spinner.