### PR TITLE
Fix ordering error on Plone site root.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.18.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix ordering error on Plone site root. [jone]
 
 
 1.18.2 (2017-03-30)

--- a/ftw/simplelayout/configuration.py
+++ b/ftw/simplelayout/configuration.py
@@ -199,7 +199,7 @@ class PageConfiguration(object):
 
         blocks = filter(ISimplelayoutBlock.providedBy,
                         map(self.context._getOb,
-                            self.context.objectIds(ordered=False)))
+                            self.context.objectIds()))
         blocks.sort(key=block_sort_key)
         return blocks
 
@@ -207,7 +207,7 @@ class PageConfiguration(object):
         """Update the positions of the sl blocks in the orderable folder.
         """
         block_ids = map(methodcaller('getId'), self.get_ordered_blocks())
-        self.context.getOrdering().moveObjectsToTop(block_ids)
+        self.context.moveObjectsToTop(block_ids)
 
     def _default_page_config(self):
         """Returns a default page config"""

--- a/ftw/simplelayout/tests/test_ordering.py
+++ b/ftw/simplelayout/tests/test_ordering.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.simplelayout.configuration import columns_in_config
+from ftw.simplelayout.configuration import synchronize_page_config_with_blocks
 from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
 from ftw.simplelayout.testing import SimplelayoutTestCase
@@ -43,6 +44,20 @@ class TestOrdering(SimplelayoutTestCase):
         self.reverse_sl_block_order(page)
         self.assert_order(page, 'block-2', 'block-1', 'page-2', 'page-1')
 
+    def test_orering_on_site_root(self):
+        portal = self.layer['portal']
+        create(Builder('sl textblock').titled(u'Block 1').within(portal))
+        create(Builder('sl textblock').titled(u'Block 2').within(portal))
+        synchronize_page_config_with_blocks(portal)
+
+        self.assertEquals(['block-1', 'block-2'],
+                          filter(lambda id_: id_.startswith('block'),
+                                 portal.objectIds()))
+        self.reverse_sl_block_order(portal)
+        self.assertEquals(['block-2', 'block-1'],
+                          filter(lambda id_: id_.startswith('block'),
+                                 portal.objectIds()))
+
     def reverse_sl_block_order(self, container):
         config = IPageConfiguration(container).load()
         for column in columns_in_config(config):
@@ -51,8 +66,7 @@ class TestOrdering(SimplelayoutTestCase):
         config = IPageConfiguration(container).store(config)
 
     def assert_order(self, container, *child_ids):
-        ordering = container.getOrdering()
-        self.assertEquals(list(child_ids), ordering.idsInOrder())
+        self.assertEquals(list(child_ids), container.objectIds())
         self.assert_positions_consistent(container)
 
     def assert_positions_consistent(self, container):


### PR DESCRIPTION
When blocks on the site root are ordered, errors occured because the site root has a different ordering implementation than folders.