### PR TITLE
update tests to be compatible with newest testbrowser.

### DIFF
--- a/ftw/simplelayout/tests/test_add_block.py
+++ b/ftw/simplelayout/tests/test_add_block.py
@@ -3,6 +3,7 @@ from ftw.builder import create
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
 from ftw.simplelayout.testing import SimplelayoutTestCase
 from ftw.testbrowser import browsing
+from ftw.testing import staticuid
 import json
 
 
@@ -41,7 +42,7 @@ class TestAddBlock(SimplelayoutTestCase):
     def test_add_block_traverser_content_contains_a_form(self, browser):
         browser.login().visit(self.page, view=self.textblockaddtraverser)
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
 
         self.assertTrue(browser.css('form'), 'No form found in content.')
 
@@ -57,35 +58,28 @@ class TestAddBlock(SimplelayoutTestCase):
         browser.login().visit(self.page, view=self.textblockaddtraverser)
         response = browser.json
 
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Title': u'This is a TextBlock',
                       'Text': u'Some text'})
         browser.find_button_by_label('Save').click()
 
-        response = browser.json
-
-        self.assertEqual(
-            'http://nohost/plone/samplecontainer/'
-            'this-is-a-textblock',
-            response['url']
-        )
-
-        browser.open_html(response['content'])
-        self.assertFalse(browser.css('form'), 'No form expected.')
-        self.assertEquals('OK',
-                          browser.contents)
+        self.assertDictContainsSubset(
+            {u'url': 'http://nohost/plone/samplecontainer/this-is-a-textblock',
+             u'content': 'OK',
+             u'proceed': True},
+            browser.json)
 
     @browsing
     def test_submit_add_block_traverser_proceed_returns_true(self, browser):
         browser.login().visit(self.page, view=self.textblockaddtraverser)
         response = browser.json
 
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Title': u'This is a TextBlock',
                       'Text': u'Some text'})
         browser.find_button_by_label('Save').click()
 
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         self.assertTrue(
             response['proceed'], 'Proceed should be true after submitting the form.')

--- a/ftw/simplelayout/tests/test_block_statusmessage.py
+++ b/ftw/simplelayout/tests/test_block_statusmessage.py
@@ -20,7 +20,7 @@ class TestBlockStatusmessage(SimplelayoutTestCase):
         browser.login().visit(self.page, view="++add_block++SampleBlock")
         response = browser.json
 
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Title': u'This is a TextBlock',
                       'Text': u'Some text'})
         browser.find_button_by_label('Save').click()
@@ -34,7 +34,7 @@ class TestBlockStatusmessage(SimplelayoutTestCase):
         browser.login().visit(block, view='edit.json')
         response = browser.json
 
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Title': u'This is a TextBlock',
                       'Text': u'Some text'})
         browser.find_button_by_label('Save').click()

--- a/ftw/simplelayout/tests/test_delete_block.py
+++ b/ftw/simplelayout/tests/test_delete_block.py
@@ -31,7 +31,7 @@ class TestBlockDelete(SimplelayoutTestCase):
                               view='@@sl-ajax-delete-blocks-view',
                               data=self.get_payload(block))
 
-        browser.open_html(browser.json['content'])
+        browser.parse(browser.json['content'])
 
         browser.find('Delete').click()
 

--- a/ftw/simplelayout/tests/test_edit_block.py
+++ b/ftw/simplelayout/tests/test_edit_block.py
@@ -67,7 +67,7 @@ class TestEditBlock(SimplelayoutTestCase):
     def test_edit_a_block_content_contains_a_form(self, browser):
         browser.login().visit(self.block, view='edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
 
         self.assertTrue(browser.css('form'), 'No form found in content.')
 
@@ -83,28 +83,25 @@ class TestEditBlock(SimplelayoutTestCase):
         browser.login().visit(self.block, view='edit.json')
         response = browser.json
 
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Title': u'This is a TextBlock',
                       'Text': u'Some text'})
         browser.find_button_by_label('Save').click()
 
-        response = browser.json
-        browser.open_html(response['content'])
-        self.assertFalse(browser.css('form'), 'No form expected.')
-        self.assertEquals('OK',
-                          browser.contents)
+        self.assertEquals(
+            {'content': 'OK', 'proceed': True},
+            browser.json)
 
     @browsing
     def test_submit_add_block_traverser_proceed_returns_true(self, browser):
         browser.login().visit(self.block, view='edit.json')
         response = browser.json
 
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Title': u'This is a TextBlock',
                       'Text': u'Some text'})
         browser.find_button_by_label('Save').click()
 
         response = browser.json
-        browser.open_html(response['content'])
         self.assertTrue(
             response['proceed'], 'Proceed should be true after submitting the form.')

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -197,7 +197,7 @@ class TestGalleryBlock(TestCase):
         # Edit the block and make appear again.
         browser.visit(galleryblock, view='edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Hide the block': False}).submit()
 
         # The block must no longer have a class "hidden".

--- a/ftw/simplelayout/tests/test_inner_edit_block.py
+++ b/ftw/simplelayout/tests/test_inner_edit_block.py
@@ -76,7 +76,7 @@ class TestInnerEdit(SimplelayoutTestCase):
     def test_inner_edit_content_contains_a_form(self, browser):
         browser.login().visit(self.innercontent, view='inner_edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
 
         self.assertTrue(browser.css('form'), 'No form found in content.')
 
@@ -92,27 +92,17 @@ class TestInnerEdit(SimplelayoutTestCase):
         browser.login().visit(self.innercontent, view='inner_edit.json')
         response = browser.json
 
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Title': u'This is a title'})
         browser.find_button_by_label('Save').click()
-
-        response = browser.json
-        browser.open_html(response['content'])
-        self.assertFalse(browser.css('form'), 'No form expected.')
-        self.assertEquals('OK',
-                          browser.contents)
+        self.assertEquals({u'content': u'OK', u'proceed': True}, browser.json)
 
     @browsing
     def test_submit_inner_block_traverser_proceed_returns_true(self, browser):
         browser.login().visit(self.innercontent, view='inner_edit.json')
         response = browser.json
 
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Title': u'This is a title'})
         browser.find_button_by_label('Save').click()
-
-        response = browser.json
-        browser.open_html(response['content'])
-        self.assertTrue(
-            response['proceed'],
-            'Proceed should be true after submitting the form.')
+        self.assertEquals({u'content': u'OK', u'proceed': True}, browser.json)

--- a/ftw/simplelayout/tests/test_listingblock.py
+++ b/ftw/simplelayout/tests/test_listingblock.py
@@ -164,7 +164,7 @@ class TestListingBlock(TestCase):
         # Edit the block and make appear again.
         browser.visit(listingblock, view='edit.json')
         response = browser.json
-        browser.open_html(response['content'])
+        browser.parse(response['content'])
         browser.fill({'Hide the block': False, 'Columns': 'Type'}).submit()
 
         # The block must no longer have a class "hidden".

--- a/ftw/simplelayout/tests/test_opengraph.py
+++ b/ftw/simplelayout/tests/test_opengraph.py
@@ -81,7 +81,8 @@ class TestOpenGraph(TestCase):
         browser.login().visit(page)
 
         tag = page.restrictedTraverse('@@leadimage')()
-        src = browser.open_html(tag).css('img').first.attrib['src']
+        browser.parse(tag)
+        src = browser.css('img').first.attrib['src']
 
         browser.login().visit(page)
         self.assertOg('og:image', src)

--- a/ftw/simplelayout/tests/test_simplelayout_view.py
+++ b/ftw/simplelayout/tests/test_simplelayout_view.py
@@ -400,15 +400,15 @@ class TestSimplelayoutView(SimplelayoutTestCase):
         storage = self.payload.copy()
         sl_renderer = SimplelayoutRenderer(self.container, storage, 'default')
 
-        browser.open_html(sl_renderer.render_layout(index=1))
+        browser.parse(sl_renderer.render_layout(index=1))
         self.assertEquals(1, len(browser.css('.sl-layout')),
                           'Expect only one layout')
 
-        browser.open_html(sl_renderer.render_layout(index=0))
+        browser.parse(sl_renderer.render_layout(index=0))
         self.assertEquals(1, len(browser.css('.sl-layout')),
                           'Expect only one layout')
 
-        browser.open_html(sl_renderer.render_layout())
+        browser.parse(sl_renderer.render_layout())
         self.assertEquals(2, len(browser.css('.sl-layout')),
                           'Expect both layouts')
 


### PR DESCRIPTION
The testbrowser has changed:
after opening a static document (open_html) it is no longer possible to continue with clicking in the loaded document, since the browser is missing state such as an URL and the static driver does not support making requests.

The correct solution is to use `.parse()` instead of `.open_html()` so that the driver does not change and later requests are done with the original driver.

I have also simplified some tests.