### PR TITLE
Add more sorting options to the gallery block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.18.4 (unreleased)
 -------------------
 
+- Add more sorting options (position in parent, id) to the gallery block. [mbaechtold]
+
 - Move print styles accidentally defined in plonetheme.blueberry. [Kevin Bieri]
 
 - Migration: Handle different simplelayout layouts. [lknoepfel]

--- a/ftw/simplelayout/contenttypes/contents/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/contents/galleryblock.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from ftw.simplelayout import _
 from ftw.simplelayout.browser.actions import DefaultActions
+from ftw.simplelayout.contenttypes.contents.filelistingblock import sort_index_vocabulary as filelisting_block_sort_index_vocabulary
 from ftw.simplelayout.contenttypes.contents.interfaces import IGalleryBlock
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
@@ -16,19 +17,15 @@ from zope.schema.vocabulary import SimpleVocabulary
 
 
 def sort_index_vocabulary(context):
-    terms = []
-    terms.append(SimpleVocabulary.createTerm(
-        'sortable_title',
-        'sortable_title',
-        _(u'label_sort_by_title',
-            default=u'Title')))
-    terms.append(SimpleVocabulary.createTerm(
-        'modified',
-        'modified',
-        _(u'column_modified',
-            default=u'Latest changes')))
+    vocabulary = filelisting_block_sort_index_vocabulary(context)
 
-    return SimpleVocabulary(terms)
+    # Remove the option "portal type", because the gallery block only
+    # accepts objects from one type.
+    vocabulary._terms = filter(
+        lambda term: term.token != 'portal_type',
+        vocabulary._terms
+    )
+    return vocabulary
 
 directlyProvides(sort_index_vocabulary, IContextSourceBinder)
 

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -4,6 +4,7 @@ from ftw.builder import create
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
 from ftw.testbrowser import browsing
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import parent
 from unittest2 import TestCase
 import transaction
 
@@ -235,6 +236,28 @@ class TestGalleryBlock(TestCase):
         )
 
     @browsing
+    def test_available_sort_options(self, browser):
+        """
+        A safety net in case some fellow programmer modifies the sort options in 
+        the file listing block not knowing that they are used on the gallery 
+        block too.
+        """
+        gallery_block = create(Builder('sl galleryblock')
+                               .titled('My galleryblock')
+                               .within(self.page))
+        browser.login()
+        browser.visit(gallery_block, view='edit')
+        self.assertEqual(
+            [
+                ('sortable_title', 'sortable_title'),
+                ('modified', 'modified'),
+                ('id', 'id'),
+                ('getObjPositionInParent', 'Position in Folder'),
+            ],
+            browser.forms['form'].find_field('Sort by').options
+        )
+
+    @browsing
     def test_sort_by_title_ascending(self, browser):
         gallery = create(Builder('sl galleryblock')
                          .titled('My galleryblock')
@@ -371,6 +394,134 @@ class TestGalleryBlock(TestCase):
             img_title_list.append(img.get('alt').split(',')[0])
 
         self.assertEqual(img_title_list, ['b_img', 'c_img', 'a_img'])
+
+    @browsing
+    def test_sort_by_position_in_parent_ascending(self, browser):
+        gallery_block = create(Builder('sl galleryblock')
+                               .titled('My galleryblock')
+                               .having(sort_on='getObjPositionInParent')
+                               .having(sort_order='ascending')
+                               .within(self.page))
+
+        create(Builder('image')
+               .titled('a_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        img_b = create(Builder('image')
+                       .titled('b_img')
+                       .with_dummy_content()
+                       .within(gallery_block))
+
+        create(Builder('image')
+               .titled('c_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        # Move "img_b" to bottom.
+        parent(img_b).moveObjectsToBottom(img_b.getId())
+        transaction.commit()
+
+        browser.login()
+        browser.visit(gallery_block, view='block_view')
+        self.assertEqual(
+            ['a_img', 'c_img', 'b_img'],
+            [node.attrib['title'] for node in browser.css('a')]
+        )
+
+    @browsing
+    def test_sort_by_position_in_parent_descending(self, browser):
+        gallery_block = create(Builder('sl galleryblock')
+                               .titled('My galleryblock')
+                               .having(sort_on='getObjPositionInParent')
+                               .having(sort_order='descending')
+                               .within(self.page))
+
+        create(Builder('image')
+               .titled('a_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        img_b = create(Builder('image')
+                       .titled('b_img')
+                       .with_dummy_content()
+                       .within(gallery_block))
+
+        create(Builder('image')
+               .titled('c_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        # Move "img_b" to bottom.
+        parent(img_b).moveObjectsToBottom(img_b.getId())
+        transaction.commit()
+
+        browser.login()
+        browser.visit(gallery_block, view='block_view')
+        self.assertEqual(
+            ['b_img', 'c_img', 'a_img'],
+            [node.attrib['title'] for node in browser.css('a')]
+        )
+
+    @browsing
+    def test_sort_by_id_ascending(self, browser):
+        gallery_block = create(Builder('sl galleryblock')
+                               .titled('My galleryblock')
+                               .having(sort_on='id')
+                               .having(sort_order='ascending')
+                               .within(self.page))
+
+        create(Builder('image')
+               .titled('c_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        create(Builder('image')
+               .titled('a_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        create(Builder('image')
+               .titled('b_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        browser.login()
+        browser.visit(gallery_block, view='block_view')
+        self.assertEqual(
+            ['a_img', 'b_img', 'c_img'],
+            [node.attrib['title'] for node in browser.css('a')]
+        )
+
+    @browsing
+    def test_sort_by_id_descending(self, browser):
+        gallery_block = create(Builder('sl galleryblock')
+                               .titled('My galleryblock')
+                               .having(sort_on='id')
+                               .having(sort_order='descending')
+                               .within(self.page))
+
+        create(Builder('image')
+               .titled('c_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        create(Builder('image')
+               .titled('a_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        create(Builder('image')
+               .titled('b_img')
+               .with_dummy_content()
+               .within(gallery_block))
+
+        browser.login()
+        browser.visit(gallery_block, view='block_view')
+        self.assertEqual(
+            ['c_img', 'b_img', 'a_img'],
+            [node.attrib['title'] for node in browser.css('a')]
+        )
 
     @browsing
     def test_image_title_with_umlaut(self, browser):


### PR DESCRIPTION
The new sorting options are position in parent, id and portal type. Just like the file listing block. In fact, the same vocabulary holding the sorting options is used for the file listing block and the gallery block now.