### PR TITLE
Change display mode of link tag around images in textblocks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.18.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Change display mode (inline-block) of link tag around images in textblocks. [mbaechtold]
 
 
 1.18.4 (2017-06-15)

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -31,6 +31,11 @@
       width: 50%;
     }
   }
+  .imageContainer {
+    > a {
+      display: inline-block;
+    }
+  }
   img {
     vertical-align: middle;
   }


### PR DESCRIPTION
This makes the link span around the entire image. Until now it was not large enough.