### PR TITLE
Fix tests.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.18.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix tests by using the latest "collective.dexteritytextindexer". [mbaechtold]
 
 
 1.18.4 (2017-06-15)

--- a/sources.cfg
+++ b/sources.cfg
@@ -6,3 +6,4 @@ extensions +=
     mr.developer
 
 auto-checkout =
+    collective.dexteritytextindexer


### PR DESCRIPTION
🚧 DO NOT MERGE YET 🚧 
🚧 WE NEED TO WAIT FOR A RELEASE OF "collective.dexteritytextindexer" 🚧 

Using the latest "collective.dexteritytextindexer" will fix the tests.

The fix we're interested in resides in the pull request https://github.com/collective/collective.dexteritytextindexer/pull/24, which has not been released yet.

Also see https://github.com/collective/collective.dexteritytextindexer/issues/28