### PR TITLE
Use a static vocabulary for the sort options of the gallery block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.18.5 (unreleased)
 -------------------
 
+- Use a static vocabulary for the sort options of the gallery block. [mbaechtold]
+
 - Install ftw.iframefix
   [Kevin Bieri]
 

--- a/ftw/simplelayout/contenttypes/contents/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/contents/galleryblock.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 from ftw.simplelayout import _
 from ftw.simplelayout.browser.actions import DefaultActions
-from ftw.simplelayout.contenttypes.contents.filelistingblock import sort_index_vocabulary as filelisting_block_sort_index_vocabulary
 from ftw.simplelayout.contenttypes.contents.interfaces import IGalleryBlock
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Container
@@ -9,25 +8,29 @@ from plone.directives import form
 from zope import schema
 from zope.i18n import translate
 from zope.interface import alsoProvides
-from zope.interface import directlyProvides
 from zope.interface import implements
-from zope.schema.interfaces import IContextSourceBinder
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
 
-def sort_index_vocabulary(context):
-    vocabulary = filelisting_block_sort_index_vocabulary(context)
-
-    # Remove the option "portal type", because the gallery block only
-    # accepts objects from one type.
-    vocabulary._terms = filter(
-        lambda term: term.token != 'portal_type',
-        vocabulary._terms
+sort_index_vocabulary = SimpleVocabulary([
+    SimpleTerm(
+        value='sortable_title',
+        title=_(u'label_title', default=u'Title')
+    ),
+    SimpleTerm(
+        value='modified',
+        title=_(u'label_modified', default=u'Modification date')
+    ),
+    SimpleTerm(
+        value='id',
+        title=_(u'label_id', default=u'ID')
+    ),
+    SimpleTerm(
+        value='getObjPositionInParent',
+        title=_(u'label_position_in_folder', default=u'Position in Folder')
     )
-    return vocabulary
-
-directlyProvides(sort_index_vocabulary, IContextSourceBinder)
+])
 
 sort_order_vocabulary = SimpleVocabulary([
     SimpleTerm(value='ascending',

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-20 13:51+0000\n"
+"POT-Creation-Date: 2017-06-30 14:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -191,7 +191,7 @@ msgstr "Dieses behavior macht einen Inhalt geo-referenzierbar"
 
 #: ./ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt:8
 #: ./ftw/simplelayout/contenttypes/browser/templates/listingblock.pt:10
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:30
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:31
 msgid "This block is empty."
 msgstr "Dieser Block hat keinen Inhalt."
 
@@ -250,7 +250,6 @@ msgstr "Ersteller"
 
 #. Default: "modified"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:55
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:28
 msgid "column_modified"
 msgstr "Bearbeitet"
 
@@ -316,7 +315,7 @@ msgid "help_drag_hint"
 msgstr "Bitte den Inhalt per Drag & Drop hinzufügen."
 
 #. Default: "Image caption:"
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:25
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:26
 msgid "hidden_label_image_caption"
 msgstr "Bild Legende:"
 
@@ -411,6 +410,8 @@ msgstr "Dateien über Inhalte verwalten."
 msgid "label_folder_contents_images"
 msgstr "Bilder über Inhalte verwalten."
 
+#. Default: "ID"
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:27
 msgid "label_id"
 msgstr "ID"
 
@@ -444,6 +445,8 @@ msgstr "Interne Referenz"
 msgid "label_is_hidden"
 msgstr "Block verstecken"
 
+#. Default: "Modification date"
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
 msgid "label_modified"
 msgstr "Bearbeitungsdatum"
 
@@ -467,6 +470,7 @@ msgstr "Typ"
 
 #. Default: "Position in Folder"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:108
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:31
 msgid "label_position_in_folder"
 msgstr "Ordnerreihenfolge"
 
@@ -476,11 +480,6 @@ msgstr "Ordnerreihenfolge"
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:35
 msgid "label_show_title"
 msgstr "Titel anzeigen?"
-
-#. Default: "Title"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
-msgid "label_sort_by_title"
-msgstr "Sortieren nach Titel"
 
 #. Default: "Sort by"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:144
@@ -498,13 +497,13 @@ msgid "label_sortable_title"
 msgstr "Titel"
 
 #. Default: "Text"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:41
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:42
 msgid "label_text"
 msgstr "Text"
 
 #. Default: "Title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:129
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:48
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:19
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:31
 msgid "label_title"
 msgstr "Titel"

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-20 13:51+0000\n"
+"POT-Creation-Date: 2017-06-30 14:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -194,7 +194,7 @@ msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt:8
 #: ./ftw/simplelayout/contenttypes/browser/templates/listingblock.pt:10
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:30
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:31
 msgid "This block is empty."
 msgstr ""
 
@@ -253,7 +253,6 @@ msgstr ""
 
 #. Default: "modified"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:55
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:28
 msgid "column_modified"
 msgstr ""
 
@@ -319,7 +318,7 @@ msgid "help_drag_hint"
 msgstr ""
 
 #. Default: "Image caption:"
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:25
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:26
 msgid "hidden_label_image_caption"
 msgstr ""
 
@@ -414,6 +413,8 @@ msgstr ""
 msgid "label_folder_contents_images"
 msgstr ""
 
+#. Default: "ID"
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:27
 msgid "label_id"
 msgstr ""
 
@@ -447,6 +448,8 @@ msgstr ""
 msgid "label_is_hidden"
 msgstr ""
 
+#. Default: "Modification date"
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
 msgid "label_modified"
 msgstr ""
 
@@ -470,6 +473,7 @@ msgstr ""
 
 #. Default: "Position in Folder"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:108
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:31
 msgid "label_position_in_folder"
 msgstr ""
 
@@ -478,11 +482,6 @@ msgstr ""
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:52
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:35
 msgid "label_show_title"
-msgstr ""
-
-#. Default: "Title"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
-msgid "label_sort_by_title"
 msgstr ""
 
 #. Default: "Sort by"
@@ -501,13 +500,13 @@ msgid "label_sortable_title"
 msgstr ""
 
 #. Default: "Text"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:41
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:42
 msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:129
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:48
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:19
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:31
 msgid "label_title"
 msgstr ""

--- a/ftw/simplelayout/locales/ftw.simplelayout-manual.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout-manual.pot
@@ -20,11 +20,5 @@ msgstr ""
 msgid "label_portal_type"
 msgstr ""
 
-msgid "label_modified"
-msgstr ""
-
-msgid "label_id"
-msgstr ""
-
 msgid "label_documentDate"
 msgstr ""

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-12-20 13:51+0000\n"
+"POT-Creation-Date: 2017-06-30 14:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -194,7 +194,7 @@ msgstr ""
 
 #: ./ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt:8
 #: ./ftw/simplelayout/contenttypes/browser/templates/listingblock.pt:10
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:30
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:31
 msgid "This block is empty."
 msgstr ""
 
@@ -253,7 +253,6 @@ msgstr ""
 
 #. Default: "modified"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:55
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:28
 msgid "column_modified"
 msgstr ""
 
@@ -319,7 +318,7 @@ msgid "help_drag_hint"
 msgstr ""
 
 #. Default: "Image caption:"
-#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:25
+#: ./ftw/simplelayout/contenttypes/browser/templates/textblock.pt:26
 msgid "hidden_label_image_caption"
 msgstr ""
 
@@ -414,6 +413,8 @@ msgstr ""
 msgid "label_folder_contents_images"
 msgstr ""
 
+#. Default: "ID"
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:27
 msgid "label_id"
 msgstr ""
 
@@ -447,6 +448,8 @@ msgstr ""
 msgid "label_is_hidden"
 msgstr ""
 
+#. Default: "Modification date"
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
 msgid "label_modified"
 msgstr ""
 
@@ -470,6 +473,7 @@ msgstr ""
 
 #. Default: "Position in Folder"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:108
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:31
 msgid "label_position_in_folder"
 msgstr ""
 
@@ -478,11 +482,6 @@ msgstr ""
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:52
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:35
 msgid "label_show_title"
-msgstr ""
-
-#. Default: "Title"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
-msgid "label_sort_by_title"
 msgstr ""
 
 #. Default: "Sort by"
@@ -501,13 +500,13 @@ msgid "label_sortable_title"
 msgstr ""
 
 #. Default: "Text"
-#: ./ftw/simplelayout/contenttypes/contents/textblock.py:41
+#: ./ftw/simplelayout/contenttypes/contents/textblock.py:42
 msgid "label_text"
 msgstr ""
 
 #. Default: "Title"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:129
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:48
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:19
 #: ./ftw/simplelayout/contenttypes/contents/textblock.py:31
 msgid "label_title"
 msgstr ""

--- a/ftw/simplelayout/tests/test_galleryblock.py
+++ b/ftw/simplelayout/tests/test_galleryblock.py
@@ -237,11 +237,6 @@ class TestGalleryBlock(TestCase):
 
     @browsing
     def test_available_sort_options(self, browser):
-        """
-        A safety net in case some fellow programmer modifies the sort options in 
-        the file listing block not knowing that they are used on the gallery 
-        block too.
-        """
         gallery_block = create(Builder('sl galleryblock')
                                .titled('My galleryblock')
                                .within(self.page))
@@ -249,9 +244,9 @@ class TestGalleryBlock(TestCase):
         browser.visit(gallery_block, view='edit')
         self.assertEqual(
             [
-                ('sortable_title', 'sortable_title'),
-                ('modified', 'modified'),
-                ('id', 'id'),
+                ('sortable_title', 'Title'),
+                ('modified', 'Modification date'),
+                ('id', 'ID'),
                 ('getObjPositionInParent', 'Position in Folder'),
             ],
             browser.forms['form'].find_field('Sort by').options


### PR DESCRIPTION
Until now the sort options were based on the columns of the file listing block. If the colums were customized, unwanted sort option would have been applied to the gallery block.