### PR TITLE
Handle view names in unicode strings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.18.5 (unreleased)
 -------------------
 
+- Handle view names in unicode strings. [mbaechtold]
+
 - Add anchor to new created blocks. [Kevin Bieri]
 
 - The galleryblock now renders a fallback image when the image to be displayed is truncated. [mbaechtold]

--- a/ftw/simplelayout/tests/test_utils.py
+++ b/ftw/simplelayout/tests/test_utils.py
@@ -1,0 +1,30 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.properties import BLOCK_PROPERTIES_KEY
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
+from ftw.simplelayout.utils import get_block_html
+from ftw.testbrowser import browsing
+from Persistence import PersistentMapping
+from unittest2 import TestCase
+from zope.annotation import IAnnotations
+
+
+class TestUtils(TestCase):
+
+    layer = FTW_SIMPLELAYOUT_CONTENT_TESTING
+
+    @browsing
+    def test_get_html_block_with_unicode_viewname(self, browser):
+        page = create(Builder('sl content page'))
+        block = create(Builder('sl textblock')
+                       .within(page)
+                       .titled(u'My Text Block'))
+
+        # Set a unicode view name.
+        annotations = IAnnotations(block)
+        if BLOCK_PROPERTIES_KEY not in annotations:
+            annotations[BLOCK_PROPERTIES_KEY] = PersistentMapping({
+                'view-name': u'block_view'
+            })
+
+        self.assertIn(u'My Text Block', get_block_html(block))

--- a/ftw/simplelayout/utils.py
+++ b/ftw/simplelayout/utils.py
@@ -1,6 +1,7 @@
 from ftw.simplelayout.interfaces import IBlockProperties
 from ftw.simplelayout.interfaces import ISimplelayoutBlock
 from plone.dexterity.interfaces import IDexterityFTI
+from plone.dexterity.utils import safe_utf8
 from plone.i18n.normalizer.interfaces import IIDNormalizer
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
@@ -17,7 +18,7 @@ def get_block_html(block):
     properties = queryMultiAdapter((block, block.REQUEST),
                                    IBlockProperties)
     viewname = properties.get_current_view_name()
-    return block.restrictedTraverse(viewname)()
+    return block.restrictedTraverse(safe_utf8(viewname))()
 
 
 def get_block_types():


### PR DESCRIPTION
This is needed when setting the view name with "ftw.inflator".