### PR TITLE
Wrap columns with container.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,10 +5,12 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
-- Introduce asymmetric layouts. [Kevin Bieri, mathias.leimgruber]
+- New Feature: Asymmetric layouts. [Kevin Bieri, mathias.leimgruber]
 
   - Introduced layout configurations (classes on layouts)
   - By default we have golden ratio-, 1-2-1-, 3-1, 1-1-2-layouts
+  - This change introduces two now wrappers (div-tag), while render the simplelayout content.
+    Please be aware that those new wrappers may break your CSS selectors.
 
 
 1.18.5 (2017-07-25)

--- a/ftw/simplelayout/browser/templates/layout.pt
+++ b/ftw/simplelayout/browser/templates/layout.pt
@@ -3,19 +3,21 @@
 
   <div tal:attributes="class python:'sl-layout-content ' + row['class'];
                        data-config row/config_json | nothing">
-    <div class="sl-column"
-         tal:repeat="col row/cols"
-         tal:attributes="class col/class">
-      <tal:blocks tal:repeat="block col/blocks">
-        <div tal:attributes="class block/css_classes;
-                             data-type block/type;
-                             data-uid block/uid;
-                             data-url block/url;">
-          <a tal:attributes="name block/id"></a>
-          <div class="sl-block-content"
-               tal:content="structure block/obj_html">Block Content</div>
-        </div>
-      </tal:blocks>
+    <div class="sl-columns">
+      <div class="sl-column"
+           tal:repeat="col row/cols"
+           tal:attributes="class col/class">
+        <tal:blocks tal:repeat="block col/blocks">
+          <div tal:attributes="class block/css_classes;
+                               data-type block/type;
+                               data-uid block/uid;
+                               data-url block/url;">
+            <a tal:attributes="name block/id"></a>
+            <div class="sl-block-content"
+                 tal:content="structure block/obj_html">Block Content</div>
+          </div>
+        </tal:blocks>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
The change introduces an additional wrapper `div` with class `sl-columns`. 
This significantly improves the styling possibilities. 

For example:
- It's possible to define a background-color for all columns
- It's possible to manipulate the floating grid

This change may break stylings of ftw.simplelyout < 1.19.x
Also #428 introduced a layout wrapper. 

Example integration:
https://github.com/4teamwork/stadtwerk.web/pull/75