### PR TITLE
Handle view names in unicode strings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.19.0 (unreleased)
 -------------------
 
+- Handle view names in unicode strings. [mbaechtold]
+
 - New Feature: Asymmetric layouts. [Kevin Bieri, mathias.leimgruber]
 
   - Introduced layout configurations (classes on layouts)

--- a/ftw/simplelayout/properties.py
+++ b/ftw/simplelayout/properties.py
@@ -1,5 +1,6 @@
 from ftw.simplelayout.interfaces import IBlockProperties
 from Persistence import PersistentMapping
+from plone.dexterity.utils import safe_utf8
 from zope.annotation import IAnnotations
 from zope.interface import implements
 
@@ -35,4 +36,4 @@ class MultiViewBlockProperties(object):
         return annotations[BLOCK_PROPERTIES_KEY]
 
     def is_view_available(self, name):
-        return self.context.restrictedTraverse(name, None) is not None
+        return self.context.restrictedTraverse(safe_utf8(name), None) is not None

--- a/ftw/simplelayout/tests/test_multiview_block_properties.py
+++ b/ftw/simplelayout/tests/test_multiview_block_properties.py
@@ -36,6 +36,14 @@ class TestMultiViewBlockProperties(SimplelayoutTestCase):
         self.assertEqual(properties.get_current_view_name(),
                          'block_view_different')
 
+    def test_changing_view_unicode(self):
+        properties = getMultiAdapter((self.block, self.block.REQUEST),
+                                     IBlockProperties)
+
+        properties.set_view(u'block_view_different')
+        self.assertEqual(properties.get_current_view_name(),
+                         'block_view_different')
+
     def test_setting_invalid_view_name_raises_error(self):
         properties = getMultiAdapter((self.block, self.block.REQUEST),
                                      IBlockProperties)


### PR DESCRIPTION
This is needed when setting the view name with "ftw.inflator".

This is related to https://github.com/4teamwork/ftw.simplelayout/pull/455