### PR TITLE
Synchronize page config with blocks plone.restapi integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -275,6 +275,15 @@ has the css class ``inneredit`` and a data attribute named ``uid`` containing th
 
 After editing the content, the view automatically reloads the block.
 
+Additional plone.restapi methods
+--------------------------------
+
+After creating blocks in a simplelayout content page they should be synchronized with the pages config. Otherwise
+the order in the frontend might me wrong. It also removes objects which are in the pages config but not in the page itself.
+
+To do this, you can simply send a RestAPI Post (more information about
+`plone.restapi <https://github.com/plone/plone.restapi>`_ ) request to the path of your page, appended with
+``@sl-synchronize-page-config-with-blocks``. A dict with ``added`` and ``removed`` block UIDs is returned.
 
 Run custom JS code
 ==================

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.21.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add plone.restapi endpoint for synchronizing blocks with the page config [Nachtalb]
 
 
 1.21.1 (2018-07-06)

--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -27,6 +27,7 @@
 
     <include package=".contenttypes" zcml:condition="have ftw.simplelayout:contenttypes" />
     <include package=".mapblock" zcml:condition="have ftw.simplelayout:contenttypes:mapblock" />
+    <include package=".restapi" zcml:condition="installed plone.restapi" />
 
     <cmf:registerDirectory
             name="ftw.simplelayout"

--- a/ftw/simplelayout/restapi/configure.zcml
+++ b/ftw/simplelayout/restapi/configure.zcml
@@ -1,0 +1,15 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
+
+  <include package="plone.rest" file="meta.zcml" />
+
+  <plone:service
+      method="POST"
+      name="@sl-synchronize-page-config-with-blocks"
+      for="ftw.simplelayout.interfaces.ISimplelayout"
+      factory=".services.SynchronizePageConfigWithBlocks"
+      permission="cmf.ModifyPortalContent"
+      />
+</configure>

--- a/ftw/simplelayout/restapi/services.py
+++ b/ftw/simplelayout/restapi/services.py
@@ -1,0 +1,8 @@
+from plone.restapi.services import Service
+from ftw.simplelayout.configuration import synchronize_page_config_with_blocks
+
+
+class SynchronizePageConfigWithBlocks(Service):
+
+    def reply(self):
+        return synchronize_page_config_with_blocks(self.context)


### PR DESCRIPTION
This implements a plone.restapi endpoint, with which you can synchronize the pages config with the existing blocks. This is needed after adding new blocks to a sl content page. Otherwise the blocks are added but are not visible in the FrontEnd.