### PR TITLE
Improve content page builder.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.19.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Content page builder only synchronises page config if the
+  page contains blocks. [mbaechtold]
 
 
 1.19.0 (2017-11-01)

--- a/ftw/simplelayout/tests/builders.py
+++ b/ftw/simplelayout/tests/builders.py
@@ -20,8 +20,9 @@ class ContenPageBuilder(DexterityBuilder):
         return self
 
     def after_create(self, obj):
-        map(create, map(methodcaller('within', obj), self.block_builders))
-        synchronize_page_config_with_blocks(obj)
+        if self.block_builders:
+            map(create, map(methodcaller('within', obj), self.block_builders))
+            synchronize_page_config_with_blocks(obj)
         return super(ContenPageBuilder, self).after_create(obj)
 
 builder_registry.register('sl content page', ContenPageBuilder)


### PR DESCRIPTION
The content page builder now only synchronises page config if the page contains blocks.

This is relevant in combination with "ftw.activity" and caused a "changed" activity to be recorded, in addition to the regular "created" activity.