### PR TITLE
Store the zoom level and the chosen map layer per mapblock. 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,9 @@ Changelog
 - Content page builder only synchronises page config if the
   page contains blocks. [mbaechtold]
 
+- Implement persisten map layer and zoom value.
+  Both can be chosen in the edit widget and will be reused on the display widget. [mathias.leimgruber]
+
 
 1.19.0 (2017-11-01)
 -------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,8 @@ Changelog
 - Content page builder only synchronises page config if the
   page contains blocks. [mbaechtold]
 
+- Implement more specific MapLayers factory to prevent adding the same layers multiple times. [mathias.leimgruber]
+
 - Implement persisten map layer and zoom value.
   Both can be chosen in the edit widget and will be reused on the display widget. [mathias.leimgruber]
 

--- a/ftw/simplelayout/mapblock/browser/configure.zcml
+++ b/ftw/simplelayout/mapblock/browser/configure.zcml
@@ -31,4 +31,12 @@
         template="templates/map_display.pt"
         />
 
+    <!-- Implement more specific MapLayers factory to prevent adding the same layers multiple times -->
+    <adapter
+        for="zope.interface.Interface
+             ftw.simplelayout.interfaces.ISimplelayoutLayer
+             zope.interface.Interface
+             collective.geo.mapwidget.interfaces.IMapWidget"
+        factory=".widget.FixedMapLayers" />
+
 </configure>

--- a/ftw/simplelayout/mapblock/browser/mapblock.py
+++ b/ftw/simplelayout/mapblock/browser/mapblock.py
@@ -1,6 +1,22 @@
+from collective.geo.mapwidget.browser.widget import MapWidget
 from ftw.simplelayout.browser.blocks.base import BaseBlock
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from collective.geo.mapwidget.browser.widget import MapWidget
+
+
+class BlockMapWidget(MapWidget):
+
+    def map_defaults(self):
+        defaults = super(BlockMapWidget, self).map_defaults()
+
+        zoom = getattr(self.context, 'zoomlevel', None)
+        if zoom is not None:
+            defaults['zoom'] = zoom
+
+        maplayer = getattr(self.context, 'maplayer', None)
+        if maplayer is not None:
+            defaults['maplayer'] = maplayer
+
+        return defaults
 
 
 class MapBlockView(BaseBlock):
@@ -8,7 +24,7 @@ class MapBlockView(BaseBlock):
     template = ViewPageTemplateFile('templates/mapblock.pt')
 
     def get_address_map(self):
-        address_map = MapWidget(self, self.request, self.context)
+        address_map = BlockMapWidget(self, self.request, self.context)
         address_map.mapid = "geo-%s" % self.context.getId()
         address_map.addClass('block-map')
         address_map.klass = 'blockwidget-cgmap'

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -67,6 +67,11 @@
           mapWidgets.collectivegeo("add_edit_layer");
           mapWidgets.collectivegeo("add_geocoder");
 
+          if (mapWidgets.data('collectivegeo') === undefined) {
+            // No widget initialized
+            return;
+          }
+
           var ol_map = mapWidgets.data('collectivegeo').mapwidget.map;
           ol_map.events.register('zoomend', ol_map, function(event){
             var zoom = event.object.zoom;

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -49,6 +49,13 @@
       }
     });
 
+    // XXX - Since I'm not able to set the map zoom level correct in any other way
+    // XXX - This satanic option is my most economic solution so far.
+    $(window).on('maploadend', function(event, map){
+      setTimeout(function(){
+          map.map.setCenter(map.map.center, map.settings.zoom);
+        }, 200);
+    });
 
     $(document).on("onLoad", ".overlay", function() {
 
@@ -59,6 +66,24 @@
           maps.collectivegeo();
           mapWidgets.collectivegeo("add_edit_layer");
           mapWidgets.collectivegeo("add_geocoder");
+
+          var ol_map = mapWidgets.data('collectivegeo').mapwidget.map;
+          ol_map.events.register('zoomend', ol_map, function(event){
+            var zoom = event.object.zoom;
+            var zoomField = $('#form-widgets-zoomlevel');
+
+            if (zoomField !== undefined) {
+              zoomField.val(zoom);
+            }
+          });
+
+          ol_map.events.register('changebaselayer', ol_map, function(event){
+            var layer = event.object.baseLayer.name;
+            var layerField = $('#form-widgets-maplayer');
+            if (layerField !== undefined) {
+              layerField.val(layer);
+            }
+          });
 
           // Fix mouse pointer position according to openlayers pointer
           $(mapWidgets.closest(".pb-ajax")).on("scroll", function(){
@@ -76,9 +101,7 @@
                   curpanel.find('.map-widget .blockwidget-cgmap').collectivegeo('add_geocoder');
               });
           }
-
         }
-
       };
 
       if (typeof google === 'object' && typeof google.maps === 'object'){

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -55,6 +55,15 @@
       setTimeout(function(){
           map.map.setCenter(map.map.center, map.settings.zoom);
         }, 200);
+
+
+        // Set base layer based on settings
+        var maplayer = $(map.trigger).data('maplayer');
+        if (maplayer) {
+          var initLayer = map.map.getLayersByName(maplayer);
+          map.map.setBaseLayer(initLayer[0]);
+        }
+
     });
 
     $(document).on("onLoad", ".overlay", function() {

--- a/ftw/simplelayout/mapblock/browser/templates/map_input.pt
+++ b/ftw/simplelayout/mapblock/browser/templates/map_input.pt
@@ -26,7 +26,8 @@
               data-cgeolongitude map_defaults/longitude|nothing;
               data-cgeozoom map_defaults/zoom|nothing;
               data-cgeolang map_defaults/lang|nothing;
-              data-geocoderurl map_defaults/geocoderurl|nothing;">
+              data-geocoderurl map_defaults/geocoderurl|nothing;
+              data-maplayer map_defaults/maplayer|nothing;">
         <!-- openlayers map -->
       </div>
 

--- a/ftw/simplelayout/mapblock/browser/templates/mapblock.pt
+++ b/ftw/simplelayout/mapblock/browser/templates/mapblock.pt
@@ -12,7 +12,8 @@
           data-cgeolongitude map_defaults/longitude|nothing;
           data-cgeozoom map_defaults/zoom|nothing;
           data-cgeolang map_defaults/lang|nothing;
-          data-geocoderurl map_defaults/geocoderurl|nothing;">
+          data-geocoderurl map_defaults/geocoderurl|nothing;
+          data-maplayer map_defaults/maplayer|nothing;">
     <!-- openlayers map -->
   </div>
 

--- a/ftw/simplelayout/mapblock/browser/widget.py
+++ b/ftw/simplelayout/mapblock/browser/widget.py
@@ -1,5 +1,8 @@
 from collective.z3cform.mapwidget.widget import FormMapWidget
 from collective.z3cform.mapwidget.widget import IFormMapWidget
+from collective.z3cform.mapwidget.widget import MapDisplayWidget
+from ftw.simplelayout.mapblock.browser.mapblock import BlockMapWidget
+from z3c.form.interfaces import DISPLAY_MODE
 from z3c.form.interfaces import IFieldWidget
 from z3c.form.interfaces import IFormLayer
 from z3c.form.widget import FieldWidget
@@ -16,6 +19,12 @@ class IBlockFormMapWidget(IFormMapWidget):
 
 class BlockFormMapWidget(FormMapWidget):
     implementsOnly(IBlockFormMapWidget)
+
+    @property
+    def cgmap(self):
+        if self.mode == DISPLAY_MODE:
+            return MapDisplayWidget(self, self.request, self.context)
+        return BlockMapWidget(self, self.request, self.context)
 
 
 @adapter(IField, IFormLayer)

--- a/ftw/simplelayout/mapblock/browser/widget.py
+++ b/ftw/simplelayout/mapblock/browser/widget.py
@@ -1,3 +1,4 @@
+from collective.geo.mapwidget.browser.widget import MapLayers
 from collective.z3cform.mapwidget.widget import FormMapWidget
 from collective.z3cform.mapwidget.widget import IFormMapWidget
 from collective.z3cform.mapwidget.widget import MapDisplayWidget
@@ -32,3 +33,26 @@ class BlockFormMapWidget(FormMapWidget):
 def BlockMapFieldWidget(field, request):
     """IFieldWidget factory for FormMapWidget."""
     return FieldWidget(field, BlockFormMapWidget(request))
+
+
+class FixedMapLayers(MapLayers):
+
+    @property
+    def js(self):
+        layers = self.layers()
+        return """
+$(window).bind('mapload', function (evt, widget) {
+    // INFO: No longer load more layers if they're already there.
+    if (widget.map.layers.length !== 0) {
+        return;
+    }
+
+    widget.addLayers([
+        %(layers)s
+    ], '%(mapid)s');
+});
+
+""" % {
+            'layers': ",\n".join([l.jsfactory for l in layers]),
+            'mapid': self.widget.mapid
+        }

--- a/ftw/simplelayout/mapblock/contents/mapblock.py
+++ b/ftw/simplelayout/mapblock/contents/mapblock.py
@@ -1,7 +1,10 @@
+from collective.geo.behaviour import MessageFactory as _
 from ftw.simplelayout.mapblock.contents.interfaces import IMapBlock
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.directives import form
+from plone.supermodel import model
+from zope import schema
 from zope.interface import alsoProvides
 from zope.interface import implements
 
@@ -9,6 +12,25 @@ from zope.interface import implements
 class IMapBlockSchema(form.Schema):
     """MapBlock for simplelayout
     """
+
+    form.mode(zoomlevel='hidden')
+    zoomlevel = schema.TextLine(
+        title=u"Zoom",
+        required=False,
+    )
+
+    form.mode(maplayer='hidden')
+    maplayer = schema.TextLine(
+        title=u"Maplayer",
+        required=False,
+    )
+
+    model.fieldset(
+        'coordinates',
+        label=_(u'Coordinates'),
+        fields=('zoomlevel', 'maplayer')
+    )
+
 
 alsoProvides(IMapBlockSchema, IFormFieldProvider)
 


### PR DESCRIPTION
This PR introduces two new features:
- Store the zoom level per block
- Store the chosen maplayer per block.

Bugfix:
- No longer register maplayers multiple times.
- Delete mapblock JS error. 

Info:
The zoom level was kind of implemented before, but it did not work, this is why there is a hack implemented for this purpose. --> https://github.com/4teamwork/ftw.simplelayout/compare/mle-map-zoom-layer?expand=1#diff-145524684bb7a847c44b606522518698R52

As the comment suggests, I'm not able to fix this in a better way, since it should already work. 

In action:

![map](https://user-images.githubusercontent.com/437933/34037517-59a24c5e-e189-11e7-88b8-2fe989de5590.gif)
