### PR TITLE
Move title and show_title field into the coordinates schemata on MapBlock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.20.1 (unreleased)
 -------------------
 
+- Move title and show_title field into the coordinates schemata on MapBlock. [mathias.leimgruber]
+
 - Fix loading google / geo maps in overlays within a tab. [mathias.leimgruber]
 
 

--- a/ftw/simplelayout/mapblock/contents/mapblock.py
+++ b/ftw/simplelayout/mapblock/contents/mapblock.py
@@ -38,7 +38,7 @@ class IMapBlockSchema(form.Schema):
     model.fieldset(
         'coordinates',
         label=CGMF(u'Coordinates'),
-        fields=('zoomlevel', 'maplayer')
+        fields=('zoomlevel', 'maplayer', 'title', 'show_title')
     )
 
 


### PR DESCRIPTION
This results in having only 1 tab, instead of two.