### PR TITLE
Always get scaled image when opening colorbox overlay to fix caching issue

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.20.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Scale images for colorbox overlay view to fix edge case cashing of images. [raphael-s]
 
 
 1.20.1 (2018-03-01)

--- a/ftw/simplelayout/contenttypes/browser/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/browser/galleryblock.py
@@ -45,6 +45,18 @@ class GalleryBlockView(BaseBlock):
                            mapping={'title': title}),
                          context=self.request)
 
+    def get_full_image_scale(self, img):
+        scales = img.restrictedTraverse('@@images')
+        try:
+            scale = scales.scale('image', scale='sl_galleryblock_4k', direction='up')
+        except IOError:
+            scale = None
+
+        if not scale:
+            scale = self._get_fallback_image_scale()
+
+        return scale.absolute_url()
+
     def get_image_scale_tag(self, img):
         scales = img.restrictedTraverse('@@images')
         try:

--- a/ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt
@@ -15,7 +15,7 @@
 				tal:attributes="
 					title img/title_or_id;
 					rel string:colorbox-${here/getId};
-					href img/absolute_url">
+					href python: view.get_full_image_scale(img)">
                 <img tal:replace="structure python: view.get_image_scale_tag(img)" />
 			</a>
 		</div>

--- a/ftw/simplelayout/contenttypes/profiles/default/propertiestool.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default/propertiestool.xml
@@ -25,6 +25,7 @@
  <object name="imaging_properties" meta_type="Plone Property Sheet">
   <property name="allowed_sizes" type="lines" purge="False">
    <element value="simplelayout_galleryblock 480:480"/>
+   <element value="sl_galleryblock_4k 3840:2160"/>
    <element value="sl_textblock_small 480:480"/>
    <element value="sl_textblock_middle 800:800"/>
    <element value="sl_textblock_large 1280:1280"/>

--- a/ftw/simplelayout/contenttypes/profiles/uninstall/propertiestool.xml
+++ b/ftw/simplelayout/contenttypes/profiles/uninstall/propertiestool.xml
@@ -25,6 +25,7 @@
  <object name="imaging_properties" meta_type="Plone Property Sheet">
   <property name="allowed_sizes" type="lines" purge="False">
    <element value="simplelayout_galleryblock 480:480" remove="True"/>
+   <element value="sl_galleryblock_4k 3840:2160" remove="True"/>
    <element value="sl_textblock_small 480:480" remove="True"/>
    <element value="sl_textblock_middle 800:800" remove="True"/>
    <element value="sl_textblock_large 1280:1280" remove="True"/>

--- a/ftw/simplelayout/upgrades/20180323111432_add_new_gallery_block_image_scaling/propertiestool.xml
+++ b/ftw/simplelayout/upgrades/20180323111432_add_new_gallery_block_image_scaling/propertiestool.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<object name="portal_properties" meta_type="Plone Properties Tool">
+
+ <object name="imaging_properties" meta_type="Plone Property Sheet">
+  <property name="allowed_sizes" type="lines" purge="False">
+   <element value="sl_galleryblock_4k 3840:2160"/>
+  </property>
+ </object>
+
+</object>

--- a/ftw/simplelayout/upgrades/20180323111432_add_new_gallery_block_image_scaling/upgrade.py
+++ b/ftw/simplelayout/upgrades/20180323111432_add_new_gallery_block_image_scaling/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddNewGalleryBlockImageScaling(UpgradeStep):
+    """Add new gallery block image scaling.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
When an image in a galleryblock was deleted and replaced with another image
with the same name, the image would not reload in the colorbox overlay because
of image caching. By getting a scale url for each image in the overlay this is
now fixed, since it forces a reload of the image each time.

This is an edge case, and will rarely occur. 