### PR TITLE
Integrate with ftw.trash.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,10 @@ To have proper styles we recommend using `plonetheme.blueberry <https://github.c
 
 Plone 5 is supported but without any default contenttypes.
 
+**Trash**
+
+``ftw.simplelayout`` integrates automatically with `ftw.trash`_ when both are installed.
+
 Installation
 ============
 
@@ -646,3 +650,5 @@ Copyright
 This package is copyright by `4teamwork <http://www.4teamwork.ch/>`_.
 
 ``ftw.simplelayout`` is licensed under GNU General Public License, version 2.
+
+.. _ftw.trash: https://github.com/4teamwork/ftw.trash

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.20.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Add optional support for ``ftw.trash``. [jone]
 
 1.20.3 (2018-07-05)
 -------------------

--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -79,6 +79,11 @@
         />
 
     <adapter
+        zcml:condition="have ftw.simplelayout:trash"
+        factory=".trash.is_restoring_bock_allowed"
+        />
+
+    <adapter
         for="ftw.simplelayout.interfaces.ISimplelayout"
         factory=".configuration.PageConfiguration"
         />

--- a/ftw/simplelayout/tests/test_trash.py
+++ b/ftw/simplelayout/tests/test_trash.py
@@ -1,0 +1,41 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+from ftw.simplelayout.testing import SimplelayoutTestCase
+from ftw.trash.trasher import Trasher
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+
+
+class TestTrashIntegration(SimplelayoutTestCase):
+    layer = FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestTrashIntegration, self).setUp()
+        self.setup_sample_ftis(self.layer['portal'])
+
+    def test_requires_modify_portal_content_permission_for_restoring_blocks(self):
+        """ftw.trash by default requires the "Add portal content" permission on the
+        parent of an object in order to restore the object.
+        For simplelayout blocks we want a different behavior: since we consider blocks
+        to be part of the content of their page, restoring blocks should only work when
+        the user has the "Modify portal content" permission.
+        We wouldn't want users to be able to restore blocks of published pages, the user
+        would need to retract or revise the page first.
+        """
+
+        setRoles(self.layer['portal'], TEST_USER_ID, ['Manager'])
+
+        page = create(Builder('sample container'))
+        block = create(Builder('sample block').within(page))
+        Trasher(block).trash()
+
+        # Make sure that the default behavior does not apply by removing the
+        # add portal content permission from the user.
+        page.manage_permission('Add portal content', roles=[], acquire=False)
+
+        page.manage_permission('Modify portal content', roles=['Manager'], acquire=False)
+        self.assertTrue(Trasher(block).is_restorable())
+
+        page.manage_permission('Modify portal content', roles=[], acquire=False)
+        self.assertFalse(Trasher(block).is_restorable())

--- a/ftw/simplelayout/trash.py
+++ b/ftw/simplelayout/trash.py
@@ -1,0 +1,15 @@
+from AccessControl import getSecurityManager
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from ftw.trash.interfaces import IIsRestoreAllowedAdapter
+from zope.component import adapter
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IIsRestoreAllowedAdapter)
+@adapter(ISimplelayoutBlock, Interface)
+def is_restoring_bock_allowed(context, request):
+    parent = aq_parent(aq_inner(context))
+    return bool(getSecurityManager().checkPermission('Modify portal content', parent))

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ tests_require = [
     'transaction',
     'unittest2',
     'zope.configuration',
-    ]
+    'ftw.simplelayout [trash]',
+]
 
 extras_require = {
     'tests': tests_require,
@@ -38,6 +39,9 @@ extras_require = {
     ],
     'mapblock': [
         'collective.geo.bundle [dexterity]',
+    ],
+    'trash': [
+        'ftw.trash',
     ]
 }
 


### PR DESCRIPTION
Lets ftw.simplelayout automatically integrate with ftw.trash.

ftw.trash by default requires the "Add portal content" permission on the parent of an object in order to restore the object. For simplelayout blocks we want a different behavior: since we consider blocks to be part of the content of their page, restoring blocks should only work when the user has the "Modify portal content" permission. We wouldn't want users to be able to restore blocks of published pages, the user would need to retract or revise the page first.

The integration configures ftw.simplelayout to check for the "Modify portal content" permission whenever a user tries to restore a block.