### PR TITLE
Quick fix sl baseurl + Fix problem in FF

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Support Plone 4.3.17 (Quick fix for getting the base-url still from the base tag). [mathias.leimgruber]
 
+- Fix JS error in FF by actually passing the event object as parameter. [mathias.leimgruber]
+
 
 1.21.0 (2018-07-05)
 -------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.21.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Support Plone 4.3.17 (Quick fix for getting the base-url still from the base tag). [mathias.leimgruber]
 
 
 1.21.0 (2018-07-05)

--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -235,7 +235,7 @@
       }
     });
 
-    $(global.document).on("click", ".sl-layout .reload", function() {
+    $(global.document).on("click", ".sl-layout .reload", function(event) {
       event.preventDefault();
       var action = $(this);
       var layout = action.parents(".sl-layout").data().object;

--- a/ftw/simplelayout/browser/resources/main.js
+++ b/ftw/simplelayout/browser/resources/main.js
@@ -70,7 +70,7 @@
 
     var target = $("body");
 
-    var baseUrl = $("body").data("base-url") ? $("body").data("base-url") + "/" : $("base").attr("href");
+    var baseUrl = $("base").length === 1 ? $("base").attr("href") : $("body").data("base-url") + "/";
 
     var isUploading = function() { return global["xhr_" + $(".main-uploader").attr("id")]._filesInProgress > 0; };
 


### PR DESCRIPTION
This implements falling back on the base tag if there is one. 
This will work until plone 5, plone 5 no longer has a base-tag. This issue will be fixed within the plone 5.1.x branch (good solution)

PLUS:
Add missing event parameter. --> Fixes FF

Resolves #477 