### PR TITLE
Implement staging for simplelayout pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -285,6 +285,47 @@ To do this, you can simply send a RestAPI Post (more information about
 `plone.restapi <https://github.com/plone/plone.restapi>`_ ) request to the path of your page, appended with
 ``@sl-synchronize-page-config-with-blocks``. A dict with ``added`` and ``removed`` block UIDs is returned.
 
+
+Staging
+-------
+
+Simplelayout provides integration level tools for setting up a staging solution for content pages.
+An ``IStaging`` adapter provides the functionality for making working copies and applying the
+changed content of the working copy onto the baseline.
+Simplelayout does not provide an integration; the integration must be implemented on project level.
+
+Simple usage example:
+
+.. code-block:: python
+
+    from Acquisition import aq_inner
+    from Acquisition import aq_parent
+    from ftw.simplelayout.staging.interfaces import IStaging
+
+    # Make a working copy of "baseline" in the folder "target"
+    target = aq_parent(aq_inner(baseline))
+    working_copy = IStaging(baseline).create_working_copy(target)
+
+    # Apply the working copy content to the baseline:
+    IStaging(working_copy).apply_working_copy()
+
+    # Or discard the working copy:
+    IStaging(working_copy).discard_working_copy()
+
+Although the staging can be integrated in various ways (actions, events, etc.),
+it is usually integrated in the workflow.
+Since ``ftw.lawgiver >= 1.15.0``, it supports [intercepting transitions](https://github.com/4teamwork/ftw.lawgiver/blob/master/README.rst#intercept-and-customize-transitions),
+which can be used for integrating a staging solution.
+
+When the working copy is created, only simplelayout block children are copied from the baseline
+to the working copy. This has the advantage that a root page of a large structure can be
+revised and copied without a performance problem because of many subpages.
+
+When the working copy is applied back, the content of its children are copied back to the
+baseline. The simplalyout state and relations are updated accordingly.
+
+
+
 Run custom JS code
 ==================
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.22.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add tooling for creating a staging solution. [jone]
 
 
 1.22.3 (2018-10-03)

--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -19,9 +19,10 @@
 
     <include file="permissions.zcml" />
     <include package=".browser" />
-    <include package=".portlets" />
-    <include package=".opengraph" />
     <include package=".images" />
+    <include package=".opengraph" />
+    <include package=".portlets" />
+    <include package=".staging" />
     <include file="behaviors.zcml" />
     <include file="lawgiver.zcml" zcml:condition="installed ftw.lawgiver" />
     <include file="resources.zcml" zcml:condition="installed ftw.theming" />

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-09-24 20:38+0000\n"
+"POT-Creation-Date: 2018-10-03 15:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -96,7 +96,7 @@ msgstr "Bild"
 msgid "Image cropping"
 msgstr "Bildbearbeitung"
 
-#: ./ftw/simplelayout/interfaces.py:155
+#: ./ftw/simplelayout/interfaces.py:156
 msgid "Image cropping aspect ratios"
 msgstr "Seitenverhältnisse"
 
@@ -112,7 +112,7 @@ msgstr "Bilderauflösungslimits"
 msgid "It's not possible to have an internal_link and an external_link together"
 msgstr "Es ist nicht möglich, einen internen und externen Link gleichzeitig zu definieren."
 
-#: ./ftw/simplelayout/configure.zcml:81
+#: ./ftw/simplelayout/configure.zcml:82
 msgid "Javascript resources from client are not compressed"
 msgstr ""
 
@@ -156,7 +156,7 @@ msgstr "Zeigt die OpenGraph Meta Tags"
 msgid "Simlelayout default content types"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:56
+#: ./ftw/simplelayout/configure.zcml:57
 msgid "Simlelayout js library"
 msgstr ""
 
@@ -338,7 +338,7 @@ msgid "cropper_soft_limit_reached_width"
 msgstr "Breite: {{currentWidth}}px (optimal: {{limitWidth}}px)"
 
 #. Default: "Define the aspect ratios (https://github.com/fengyuanchen/cropperjs#options) available for your contenttypes.<br><br>Format:<br>key: contenttype<br>value: title => value<br><br>example:<br>key: ftw.simplelayout.TextBlock<br>value: 4/3 => 1.33333<br><br>Calculation: if you want a ratio of 16:9, you need to define the ratio to 1.777777778 (16/9 = 1.777777778). 0 means no ratio restrictions.<br><br>"
-#: ./ftw/simplelayout/interfaces.py:158
+#: ./ftw/simplelayout/interfaces.py:159
 msgid "desc_image_cropping_options"
 msgstr "Definieren Sie die Seitenverhältnisse (https://github.com/fengyuanchen/cropperjs#options) für Ihre Inhaltstypen.<br><br>Format:<br>key: Inhaltstyp<br>value: title => value<br><br>Beispiel:<br>key: ftw.simplelayout.TextBlock<br>value:4/3 => 1.33333<br><br>Berechnung: Wenn Sie ein Verhältnis von 16:9 zulassen wollen, dann müssen Sie als Seitenverhältnis 1.777777778 (16/9 = 1.777777778) angeben. 0 bedeutet, dass es keine Einschränkungen gibt."
 
@@ -372,11 +372,11 @@ msgstr "Dies versteckt den Block rein visuell. Dies ist kein Sicherheits-Feature
 msgid "description_teaser_fieldset"
 msgstr "Mit der Link-Funktion kann ein Block direkt mit weiterführendem Inhalt verknüpft werden.<br /> Der Titel und das Bild vom Block werden als Link mit dem Ziel verknüpft.<br /><br /> Oft wird die Linkfunktion auch auf sogenannten Triage- oder Portal-Seiten verwendet. In diesen Fällen reicht ein Link in der Navigation nicht aus, sondern der Benutzer benötigt weitere Informationen, damit dieser auf der richten Seite landet."
 
-#: ./ftw/simplelayout/configure.zcml:81
+#: ./ftw/simplelayout/configure.zcml:82
 msgid "ftw.simplelayout development"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:56
+#: ./ftw/simplelayout/configure.zcml:57
 msgid "ftw.simplelayout js library"
 msgstr ""
 
@@ -668,6 +668,16 @@ msgstr "Breite: ${width}px (aktuell: ${current_width}px)"
 #: ./ftw/simplelayout/images/limits/browser/limits.py:29
 msgid "low_quality_image_label"
 msgstr "Bildauflösung ist nicht optimal"
+
+#. Default: "${owner} is working on this page in a working copy created at ${date}."
+#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:15
+msgid "message_baseline"
+msgstr "${owner} überarbeitet diese Seite gerade in einer Arbeitskopie, erstellt am ${date}."
+
+#. Default: "This is the working copy of ${owner}, created at ${date}."
+#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:15
+msgid "message_working_copy"
+msgstr "Dies ist die Arbeitskopie von ${owner}, erstellt am ${date}."
 
 #. Default: "Optimal image quality: ${limit_str}"
 #: ./ftw/simplelayout/images/limits/validators.py:57

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-09-24 20:38+0000\n"
+"POT-Creation-Date: 2018-10-03 15:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -99,7 +99,7 @@ msgstr ""
 msgid "Image cropping"
 msgstr ""
 
-#: ./ftw/simplelayout/interfaces.py:155
+#: ./ftw/simplelayout/interfaces.py:156
 msgid "Image cropping aspect ratios"
 msgstr ""
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "It's not possible to have an internal_link and an external_link together"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:81
+#: ./ftw/simplelayout/configure.zcml:82
 msgid "Javascript resources from client are not compressed"
 msgstr ""
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Simlelayout default content types"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:56
+#: ./ftw/simplelayout/configure.zcml:57
 msgid "Simlelayout js library"
 msgstr ""
 
@@ -341,7 +341,7 @@ msgid "cropper_soft_limit_reached_width"
 msgstr ""
 
 #. Default: "Define the aspect ratios (https://github.com/fengyuanchen/cropperjs#options) available for your contenttypes.<br><br>Format:<br>key: contenttype<br>value: title => value<br><br>example:<br>key: ftw.simplelayout.TextBlock<br>value: 4/3 => 1.33333<br><br>Calculation: if you want a ratio of 16:9, you need to define the ratio to 1.777777778 (16/9 = 1.777777778). 0 means no ratio restrictions.<br><br>"
-#: ./ftw/simplelayout/interfaces.py:158
+#: ./ftw/simplelayout/interfaces.py:159
 msgid "desc_image_cropping_options"
 msgstr ""
 
@@ -375,11 +375,11 @@ msgstr ""
 msgid "description_teaser_fieldset"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:81
+#: ./ftw/simplelayout/configure.zcml:82
 msgid "ftw.simplelayout development"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:56
+#: ./ftw/simplelayout/configure.zcml:57
 msgid "ftw.simplelayout js library"
 msgstr ""
 
@@ -670,6 +670,16 @@ msgstr ""
 #: ./ftw/simplelayout/images/cropping/browser/templates/cropping_soft_limit_message.pt:5
 #: ./ftw/simplelayout/images/limits/browser/limits.py:29
 msgid "low_quality_image_label"
+msgstr ""
+
+#. Default: "${owner} is working on this page in a working copy created at ${date}."
+#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:15
+msgid "message_baseline"
+msgstr ""
+
+#. Default: "This is the working copy of ${owner}, created at ${date}."
+#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:15
+msgid "message_working_copy"
 msgstr ""
 
 #. Default: "Optimal image quality: ${limit_str}"

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-09-24 20:38+0000\n"
+"POT-Creation-Date: 2018-10-03 15:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -99,7 +99,7 @@ msgstr ""
 msgid "Image cropping"
 msgstr ""
 
-#: ./ftw/simplelayout/interfaces.py:155
+#: ./ftw/simplelayout/interfaces.py:156
 msgid "Image cropping aspect ratios"
 msgstr ""
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "It's not possible to have an internal_link and an external_link together"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:81
+#: ./ftw/simplelayout/configure.zcml:82
 msgid "Javascript resources from client are not compressed"
 msgstr ""
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "Simlelayout default content types"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:56
+#: ./ftw/simplelayout/configure.zcml:57
 msgid "Simlelayout js library"
 msgstr ""
 
@@ -341,7 +341,7 @@ msgid "cropper_soft_limit_reached_width"
 msgstr ""
 
 #. Default: "Define the aspect ratios (https://github.com/fengyuanchen/cropperjs#options) available for your contenttypes.<br><br>Format:<br>key: contenttype<br>value: title => value<br><br>example:<br>key: ftw.simplelayout.TextBlock<br>value: 4/3 => 1.33333<br><br>Calculation: if you want a ratio of 16:9, you need to define the ratio to 1.777777778 (16/9 = 1.777777778). 0 means no ratio restrictions.<br><br>"
-#: ./ftw/simplelayout/interfaces.py:158
+#: ./ftw/simplelayout/interfaces.py:159
 msgid "desc_image_cropping_options"
 msgstr ""
 
@@ -375,11 +375,11 @@ msgstr ""
 msgid "description_teaser_fieldset"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:81
+#: ./ftw/simplelayout/configure.zcml:82
 msgid "ftw.simplelayout development"
 msgstr ""
 
-#: ./ftw/simplelayout/configure.zcml:56
+#: ./ftw/simplelayout/configure.zcml:57
 msgid "ftw.simplelayout js library"
 msgstr ""
 
@@ -670,6 +670,16 @@ msgstr ""
 #: ./ftw/simplelayout/images/cropping/browser/templates/cropping_soft_limit_message.pt:5
 #: ./ftw/simplelayout/images/limits/browser/limits.py:29
 msgid "low_quality_image_label"
+msgstr ""
+
+#. Default: "${owner} is working on this page in a working copy created at ${date}."
+#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:15
+msgid "message_baseline"
+msgstr ""
+
+#. Default: "This is the working copy of ${owner}, created at ${date}."
+#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:15
+msgid "message_working_copy"
 msgstr ""
 
 #. Default: "Optimal image quality: ${limit_str}"

--- a/ftw/simplelayout/staging/configure.zcml
+++ b/ftw/simplelayout/staging/configure.zcml
@@ -1,0 +1,9 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="ftw.simplelayout">
+
+  <adapter factory=".staging.staging_lookup" />
+  <adapter factory=".staging.Staging" />
+
+</configure>

--- a/ftw/simplelayout/staging/configure.zcml
+++ b/ftw/simplelayout/staging/configure.zcml
@@ -1,9 +1,28 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:browser="http://namespaces.zope.org/browser"
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="ftw.simplelayout">
 
   <adapter factory=".staging.staging_lookup" />
   <adapter factory=".staging.Staging" />
+
+  <browser:viewlet
+      for="ftw.simplelayout.staging.interfaces.IWorkingCopy"
+      name="ftw.simplelayout.staging.viewlets.WorkingCopyViewlet"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContentTitle"
+      class="ftw.simplelayout.staging.viewlets.WorkingCopyViewlet"
+      permission="zope2.View"
+      layer="ftw.simplelayout.interfaces.ISimplelayoutLayer"
+      />
+
+  <browser:viewlet
+      for="ftw.simplelayout.staging.interfaces.IBaseline"
+      name="ftw.simplelayout.staging.viewlets.BaselineViewlet"
+      manager="plone.app.layout.viewlets.interfaces.IAboveContentTitle"
+      class="ftw.simplelayout.staging.viewlets.BaselineViewlet"
+      permission="zope2.View"
+      layer="ftw.simplelayout.interfaces.ISimplelayoutLayer"
+      />
 
 </configure>

--- a/ftw/simplelayout/staging/interfaces.py
+++ b/ftw/simplelayout/staging/interfaces.py
@@ -1,0 +1,27 @@
+from zope.interface import Interface
+
+
+class IStaging(Interface):
+    """The staging adapter provides functionality for implementing and controlling staging.
+
+    It adapts a future baseline, a baseline or a working copy.
+    """
+
+    def __init__(context, request):
+        pass
+
+    def create_working_copy(target_container):
+        """Create a copy of the currently adapted object in the target_container folder.
+        Return the working copy object.
+        """
+
+
+class IBaseline(Interface):
+    """Marker interface for baseline objects.
+    A baseline object is an object of which a working copy exists.
+    """
+
+
+class IWorkingCopy(Interface):
+    """Marker interface for working copy objects.
+    """

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -1,0 +1,87 @@
+from Acquisition import aq_base
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from BTrees.OOBTree import OOBTree
+from contextlib import contextmanager
+from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from ftw.simplelayout.staging.interfaces import IBaseline
+from ftw.simplelayout.staging.interfaces import IStaging
+from ftw.simplelayout.staging.interfaces import IWorkingCopy
+from persistent.list import PersistentList
+from zope.annotation.interfaces import IAnnotations
+from zope.component import adapter
+from zope.component import getMultiAdapter
+from zope.interface import alsoProvides
+from zope.interface import implementer
+from zope.interface import Interface
+
+
+@implementer(IStaging)
+@adapter(Interface)
+def staging_lookup(context):
+    """The staging lookup allows for an easy lookup of the adapter by
+    simply using IStaging(context).
+    We want the request to be adapted anyway, so that the adapter can be customized
+    with a browser layer.
+    """
+    return getMultiAdapter((context, context.REQUEST), IStaging)
+
+
+@implementer(IStaging)
+@adapter(Interface, Interface)
+class Staging(object):
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def create_working_copy(self, target_container):
+        """Make a working copy of the adapted context into the given target container.
+        """
+        working_copy = self._create_clone(self.context, target_container)
+        alsoProvides(self.context, IBaseline)
+        alsoProvides(working_copy, IWorkingCopy)
+        return working_copy
+
+    def _create_clone(self, obj, target_container):
+        """When cloning an object, we want to make sure that we do not clone
+        child objects which we will not use later.
+        This is important as we may make a working copy of a root node which
+        contains very large structures.
+        """
+        source_container = aq_parent(aq_inner(obj))
+        obj = aq_base(obj)
+        with self._cleanup_filter_tree(obj, ISimplelayoutBlock.providedBy), \
+             self._cleanup_filter_order(obj):
+            clipboard = source_container.manage_copyObjects([obj.getId()])
+            copy_info, = target_container.manage_pasteObjects(clipboard)
+        return target_container.get(copy_info['new_id'])
+
+    @contextmanager
+    def _cleanup_filter_tree(self, obj, condition):
+        """Filter the child objects of the ``obj`` so that ``condition`` is ``True`` for
+        each child.
+        The context manager restores on exit.
+        """
+        original = obj._tree
+        obj._tree = OOBTree({key: value for (key, value) in obj._tree.items() if condition(value)})
+        try:
+            yield
+        finally:
+            obj._tree = original
+
+    @contextmanager
+    def _cleanup_filter_order(self, obj):
+        """Cleanup order according to already cleaned up object tree.
+        The context manager restores on exit.
+        """
+        annotations = IAnnotations(obj)
+        annkey = 'plone.folder.ordered.order'
+        if annkey in annotations:
+            original = annotations[annkey]
+            annotations[annkey] = PersistentList([key for key in original if key in obj._tree])
+        try:
+            yield
+        finally:
+            if annkey in annotations:
+                annotations[annkey] = original

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -112,7 +112,7 @@ class Staging(object):
         uuid_map = self._apply_children(working_copy, baseline,
                                         condition=self.is_child_integrated)
         self._update_simplelayout_page_state(working_copy, baseline, uuid_map)
-        self._delete_and_unlink_working_copy(baseline, working_copy)
+        self._unlink_and_delete_working_copy(baseline, working_copy)
 
     def discard_working_copy(self):
         """When the adapted context is the working copy, this method discards the
@@ -123,7 +123,7 @@ class Staging(object):
 
         baseline = self.get_baseline()
         working_copy = self.context
-        self._delete_and_unlink_working_copy(baseline, working_copy)
+        self._unlink_and_delete_working_copy(baseline, working_copy)
 
     def is_child_integrated(self, obj):
         """Condition for deciding whether a child is "integrated" or not.
@@ -205,7 +205,7 @@ class Staging(object):
         del working_copy._baseline
         baseline._working_copies.remove(IUUID(working_copy))
 
-    def _delete_and_unlink_working_copy(self, baseline, working_copy):
+    def _unlink_and_delete_working_copy(self, baseline, working_copy):
         self._unlink(baseline, working_copy)
         noLongerProvides(baseline, IBaseline)
         noLongerProvides(working_copy, IWorkingCopy)

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -4,6 +4,7 @@ from Acquisition import aq_parent
 from BTrees.OOBTree import OOBTree
 from contextlib import contextmanager
 from copy import deepcopy
+from DateTime import DateTime
 from ftw.simplelayout.configuration import columns_in_config
 from ftw.simplelayout.interfaces import IBlockConfiguration
 from ftw.simplelayout.interfaces import IPageConfiguration
@@ -150,7 +151,10 @@ class Staging(object):
         with self._cleanup_filter_tree(obj), self._cleanup_filter_order(obj):
             clipboard = source_container.manage_copyObjects([obj.getId()])
             copy_info, = target_container.manage_pasteObjects(clipboard)
-        return target_container.get(copy_info['new_id'])
+        working_copy = target_container.get(copy_info['new_id'])
+        working_copy.creation_date = DateTime()
+        working_copy.reindexObject(idxs=['created'])
+        return working_copy
 
     @contextmanager
     def _cleanup_filter_tree(self, obj):

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -253,6 +253,8 @@ class Staging(object):
             source_storage = schemata(source)
             target_storage = schemata(target)
             value = getattr(source_storage, name)
+            if isinstance(value, str):
+                value = value.decode('utf-8')
             setattr(target_storage, field.getName(), value)
 
     def _copy_at_field_values(self, source, target):

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -201,25 +201,22 @@ class Staging(object):
         noLongerProvides(working_copy, IWorkingCopy)
         aq_parent(aq_inner(working_copy)).manage_delObjects([working_copy.getId()])
 
-    def _apply_children(self, source_container, target_container, condition=None,
-                        uuid_map=None):
+    def _apply_children(self, source, target, condition=None, uuid_map=None):
         uuid_map = uuid_map or {}
-        uuid_map[IUUID(source_container)] = IUUID(target_container)
-        target_children_map = {IUUID(obj): obj for obj
-                               in filter(condition, target_container.objectValues())}
-        self._copy_field_values(source_container, target_container)
-        self._update_simplelayout_block_state(source_container, target_container)
+        uuid_map[IUUID(source)] = IUUID(target)
+        target_children_map = {IUUID(obj): obj for obj in filter(condition, target.objectValues())}
+        self._copy_field_values(source, target)
+        self._update_simplelayout_block_state(source, target)
 
-        for source_obj in filter(condition, source_container.objectValues()):
-            target_uid = getattr(source_obj, '_baseline_obj_uuid', None)
+        for source_child in filter(condition, source.objectValues()):
+            target_uid = getattr(source_child, '_baseline_obj_uuid', None)
             if target_uid in target_children_map:
-                target_obj = target_children_map.pop(target_uid)
-                self._apply_children(source_obj, target_obj, uuid_map=uuid_map)
+                target_child = target_children_map.pop(target_uid)
+                self._apply_children(source_child, target_child, uuid_map=uuid_map)
             else:
-                self._move_new_obj(source_obj, target_container)
+                self._move_new_obj(source_child, target)
 
-        target_container.manage_delObjects(map(methodcaller('getId'),
-                                               target_children_map.values()))
+        target.manage_delObjects(map(methodcaller('getId'), target_children_map.values()))
         return uuid_map
 
     def _update_simplelayout_page_state(self, working_copy, baseline, uuid_map):

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -216,6 +216,7 @@ class Staging(object):
         uuid_map[IUUID(source)] = IUUID(target)
         target_children_map = {IUUID(obj): obj for obj in self._get_children(target, condition)}
         self._copy_field_values(source, target)
+        self._purge_scales(target)
         self._update_simplelayout_block_state(source, target)
 
         for source_child in self._get_children(source, condition):
@@ -302,6 +303,14 @@ class Staging(object):
         clipboard = aq_parent(aq_inner(obj)).manage_copyObjects([obj.getId()])
         info = new_parent.manage_pasteObjects(clipboard)
         return new_parent.get(info[0]['new_id'])
+
+    def _purge_scales(self, obj):
+        """When copying value from one object to another, they may include images
+        which have scales. In order to make sure that we do not use old caches,
+        we are purging the complete scaling cache so that the scales will be
+        regenerated when needed.
+        """
+        IAnnotations(obj).pop('plone.scale', None)
 
     def _get_children(self, folder, filter_condition=None):
         """Return the children of a container, supporting the trash and an arbitrary

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -222,9 +222,9 @@ class Staging(object):
             target_uid = getattr(source_child, '_baseline_obj_uuid', None)
             if target_uid in target_children_map:
                 target_child = target_children_map.pop(target_uid)
+                self._apply_children(source_child, target_child, uuid_map=uuid_map)
             else:
                 target_child = self._copy_new_obj(source_child, target)
-            self._apply_children(source_child, target_child, uuid_map=uuid_map)
 
         target.manage_delObjects(map(methodcaller('getId'), target_children_map.values()))
         return uuid_map

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -155,10 +155,13 @@ class Staging(object):
         original = obj._tree
         obj._tree = OOBTree({key: value for (key, value) in obj._tree.items()
                              if self.is_child_integrated(value)})
+        original_count = obj._count()
+        obj._count.set(len(obj._tree))
         try:
             yield
         finally:
             obj._tree = original
+            obj._count.set(original_count)
 
     @contextmanager
     def _cleanup_filter_order(self, obj):

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -9,11 +9,13 @@ from ftw.simplelayout.configuration import columns_in_config
 from ftw.simplelayout.interfaces import IBlockConfiguration
 from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from ftw.simplelayout.properties import BLOCK_PROPERTIES_KEY
 from ftw.simplelayout.staging.interfaces import IBaseline
 from ftw.simplelayout.staging.interfaces import IStaging
 from ftw.simplelayout.staging.interfaces import IWorkingCopy
 from operator import methodcaller
 from persistent.list import PersistentList
+from persistent.mapping import PersistentMapping
 from plone.app.textfield.interfaces import IRichText
 from plone.app.textfield.value import RichTextValue
 from plone.app.uuid.utils import uuidToObject
@@ -269,6 +271,14 @@ class Staging(object):
         if source_configuration:
             config = deepcopy(source_configuration.load())
             IBlockConfiguration(target).store(config)
+
+        source_ann = IAnnotations(source)
+        target_ann = IAnnotations(target)
+        if BLOCK_PROPERTIES_KEY in source_ann:
+            target_ann[BLOCK_PROPERTIES_KEY] = PersistentMapping(
+                source_ann[BLOCK_PROPERTIES_KEY])
+        else:
+            target_ann.pop(BLOCK_PROPERTIES_KEY, None)
 
     def _update_internal_links_recursively(self, obj, uuid_map, condition=None):
         if IDexterityContent.providedBy(obj):

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -64,7 +64,8 @@ class Staging(object):
         return IWorkingCopy.providedBy(self.context)
 
     def get_baseline(self):
-        """When the adapted object is a working copy, the baseline is returned, otherwise None.
+        """When the adapted object is a working copy, the baseline is returned,
+        otherwise None.
         """
         if self.is_working_copy():
             return uuidToObject(self.context._baseline)
@@ -135,8 +136,8 @@ class Staging(object):
 
     @contextmanager
     def _cleanup_filter_tree(self, obj):
-        """Filter the child objects of the ``obj`` so only children considered as "integrated"
-        are beeing kept.
+        """Filter the child objects of the ``obj`` so only children considered
+        as "integrated" are beeing kept.
         The context manager restores on exit.
         """
         original = obj._tree
@@ -156,7 +157,8 @@ class Staging(object):
         annkey = 'plone.folder.ordered.order'
         if annkey in annotations:
             original = annotations[annkey]
-            annotations[annkey] = PersistentList([key for key in original if key in obj._tree])
+            annotations[annkey] = PersistentList(
+                [key for key in original if key in obj._tree])
         try:
             yield
         finally:
@@ -165,7 +167,8 @@ class Staging(object):
 
     def _map_uuids(self, baseline, working_copy):
         """Map uuids of baseline objects and working copy objects.
-        The uuid of the baseline object is stored on the working copy object, recursively.
+        The uuid of the baseline object is stored on the working copy object,
+        recursively.
         The method returns a map from baseline objects to their working copy objects.
         """
         baseline_to_workingcopy = {}

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -247,6 +247,7 @@ class Staging(object):
                 self._apply_children(source_child, target_child, uuid_map=uuid_map)
             else:
                 target_child = self._copy_new_obj(source_child, target)
+                uuid_map[IUUID(source_child)] = IUUID(target_child)
 
         target.manage_delObjects(map(methodcaller('getId'), target_children_map.values()))
         return uuid_map

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -3,20 +3,29 @@ from Acquisition import aq_inner
 from Acquisition import aq_parent
 from BTrees.OOBTree import OOBTree
 from contextlib import contextmanager
+from ftw.simplelayout.configuration import columns_in_config
+from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.simplelayout.interfaces import ISimplelayoutBlock
 from ftw.simplelayout.staging.interfaces import IBaseline
 from ftw.simplelayout.staging.interfaces import IStaging
 from ftw.simplelayout.staging.interfaces import IWorkingCopy
+from operator import methodcaller
 from persistent.list import PersistentList
 from plone.app.uuid.utils import uuidToObject
+from plone.dexterity.interfaces import IDexterityContent
+from plone.dexterity.interfaces import IDexterityFTI
+from plone.dexterity.utils import getAdditionalSchemata
 from plone.uuid.interfaces import IUUID
+from Products.Archetypes.interfaces import IBaseContent
 from zope.annotation.interfaces import IAnnotations
 from zope.component import adapter
 from zope.component import getMultiAdapter
+from zope.component import getUtility
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.interface import Interface
 from zope.interface import noLongerProvides
+from zope.schema import getFieldsInOrder
 
 
 @implementer(IStaging)
@@ -33,6 +42,12 @@ def staging_lookup(context):
 @implementer(IStaging)
 @adapter(Interface, Interface)
 class Staging(object):
+
+    IGNORED_AT_FIELDS = (
+        'id',
+        'creation_date',
+        'modification_date',
+    )
 
     def __init__(self, context, request):
         self.context = context
@@ -69,7 +84,22 @@ class Staging(object):
         alsoProvides(self.context, IBaseline)
         alsoProvides(working_copy, IWorkingCopy)
         self._link(self.context, working_copy)
+        self._map_uuids(self.context, working_copy)
         return working_copy
+
+    def apply_working_copy(self):
+        """Apply the changes of the working copy back to the baseline and remove
+        the working copy.
+        """
+        if not self.is_working_copy():
+            raise ValueError('Adapted context must be a working copy.')
+
+        baseline = self.get_baseline()
+        working_copy = self.context
+        uuid_map = self._apply_children(working_copy, baseline,
+                                        condition=self.is_child_integrated)
+        self._update_simplelayout_page_state(working_copy, baseline, uuid_map)
+        self._delete_and_unlink_working_copy(baseline, working_copy)
 
     def discard_working_copy(self):
         """When the adapted context is the working copy, this method discards the
@@ -80,10 +110,15 @@ class Staging(object):
 
         baseline = self.get_baseline()
         working_copy = self.context
+        self._delete_and_unlink_working_copy(baseline, working_copy)
 
-        self._unlink(baseline, working_copy)
-        noLongerProvides(baseline, IBaseline)
-        aq_parent(aq_inner(working_copy)).manage_delObjects([working_copy.getId()])
+    def is_child_integrated(self, obj):
+        """Condition for deciding whether a child is "integrated" or not.
+        By "integrated" it's meant that the child is considered part of the content
+        and thus is copyied / applied along with the staged container.
+        In simplelayout this applies to simplelayout blocks by defualt.
+        """
+        return ISimplelayoutBlock.providedBy(obj)
 
     def _create_clone(self, obj, target_container):
         """When cloning an object, we want to make sure that we do not clone
@@ -93,20 +128,20 @@ class Staging(object):
         """
         source_container = aq_parent(aq_inner(obj))
         obj = aq_base(obj)
-        with self._cleanup_filter_tree(obj, ISimplelayoutBlock.providedBy), \
-             self._cleanup_filter_order(obj):
+        with self._cleanup_filter_tree(obj), self._cleanup_filter_order(obj):
             clipboard = source_container.manage_copyObjects([obj.getId()])
             copy_info, = target_container.manage_pasteObjects(clipboard)
         return target_container.get(copy_info['new_id'])
 
     @contextmanager
-    def _cleanup_filter_tree(self, obj, condition):
-        """Filter the child objects of the ``obj`` so that ``condition`` is ``True`` for
-        each child.
+    def _cleanup_filter_tree(self, obj):
+        """Filter the child objects of the ``obj`` so only children considered as "integrated"
+        are beeing kept.
         The context manager restores on exit.
         """
         original = obj._tree
-        obj._tree = OOBTree({key: value for (key, value) in obj._tree.items() if condition(value)})
+        obj._tree = OOBTree({key: value for (key, value) in obj._tree.items()
+                             if self.is_child_integrated(value)})
         try:
             yield
         finally:
@@ -128,6 +163,22 @@ class Staging(object):
             if annkey in annotations:
                 annotations[annkey] = original
 
+    def _map_uuids(self, baseline, working_copy):
+        """Map uuids of baseline objects and working copy objects.
+        The uuid of the baseline object is stored on the working copy object, recursively.
+        The method returns a map from baseline objects to their working copy objects.
+        """
+        baseline_to_workingcopy = {}
+
+        def handle(baseline_obj, working_copy_obj):
+            baseline_to_workingcopy[IUUID(baseline_obj)] = IUUID(working_copy_obj)
+            working_copy_obj._baseline_obj_uuid = IUUID(baseline_obj)
+            for name in working_copy_obj.objectIds():
+                handle(baseline_obj[name], working_copy_obj[name])
+
+        handle(baseline, working_copy)
+        return baseline_to_workingcopy
+
     def _link(self, baseline, working_copy):
         if not hasattr(baseline, '_working_copies'):
             baseline._working_copies = PersistentList()
@@ -138,3 +189,92 @@ class Staging(object):
     def _unlink(self, baseline, working_copy):
         del working_copy._baseline
         baseline._working_copies.remove(IUUID(working_copy))
+
+    def _delete_and_unlink_working_copy(self, baseline, working_copy):
+        self._unlink(baseline, working_copy)
+        noLongerProvides(baseline, IBaseline)
+        noLongerProvides(working_copy, IWorkingCopy)
+        aq_parent(aq_inner(working_copy)).manage_delObjects([working_copy.getId()])
+
+    def _apply_children(self, source_container, target_container, condition=None,
+                        uuid_map=None):
+        uuid_map = uuid_map or {}
+        uuid_map[IUUID(source_container)] = IUUID(target_container)
+        target_children_map = {IUUID(obj): obj for obj
+                               in filter(condition, target_container.objectValues())}
+        self._copy_field_values(source_container, target_container)
+
+        for source_obj in filter(condition, source_container.objectValues()):
+            target_uid = getattr(source_obj, '_baseline_obj_uuid', None)
+            if target_uid in target_children_map:
+                target_obj = target_children_map.pop(target_uid)
+                self._apply_children(source_obj, target_obj, uuid_map=uuid_map)
+            else:
+                self._move_new_obj(source_obj, target_container)
+
+        target_container.manage_delObjects(map(methodcaller('getId'),
+                                               target_children_map.values()))
+        return uuid_map
+
+    def _update_simplelayout_page_state(self, working_copy, baseline, uuid_map):
+        """Copy the simplelayout page state from the working copy to the baseline
+        and change the working copy block UUIDs to the existing baseline block UUIDs
+        unless new blocks are added.
+        """
+        config = IPageConfiguration(working_copy).load()
+        for column in columns_in_config(config):
+            for block in column['blocks']:
+                if block['uid'] in uuid_map:
+                    block['uid'] = uuid_map[block['uid']]
+
+        IPageConfiguration(baseline).store(config)
+
+    def _copy_field_values(self, source, target):
+        """Copy all fields values from "source" to "target".
+        """
+        if type(source) != type(target):
+            raise ValueError('Objects have differing classes ({!r} != {!r})'.format(
+                type(source), type(target)))
+
+        if IDexterityContent.providedBy(source):
+            return self._copy_dx_field_values(source, target)
+
+        if IBaseContent.providedBy(source):
+            return self._copy_at_field_values(source, target)
+
+        raise ValueError('Unsupported object type {!r}, neither AT nor DX.'.format(
+            source))
+
+    def _copy_dx_field_values(self, source, target):
+        for name, field, schemata in self._iter_fields(source.portal_type):
+            source_storage = schemata(source)
+            target_storage = schemata(target)
+            value = getattr(source_storage, name)
+            setattr(target_storage, field.getName(), value)
+
+    def _copy_at_field_values(self, source, target):
+        for source_field in source.Schema().values():
+            if source_field.__init__ in self.IGNORED_AT_FIELDS:
+                continue
+
+            # Re-fetch the field from the target schema since source and
+            # target schema may vary because of dynamice schema extenders.
+            target_field = target.Schema().getField(source_field.__name__)
+            value = source_field.getRaw(source)
+            target_field.set(target, value)
+
+    def _iter_fields(self, portal_type):
+        for schemata in self._iter_schemata_for_protal_type(portal_type):
+            for name, field in getFieldsInOrder(schemata):
+                if not getattr(field, 'readonly', False):
+                    yield (name, field, schemata)
+
+    def _iter_schemata_for_protal_type(self, portal_type):
+        fti = getUtility(IDexterityFTI, name=portal_type)
+        yield fti.lookupSchema()
+        for schema in getAdditionalSchemata(portal_type=portal_type):
+            yield schema
+
+    def _move_new_obj(self, obj, new_parent):
+        clipboard = aq_parent(aq_inner(obj)).manage_cutObjects([obj.getId()])
+        new_parent.manage_pasteObjects(clipboard)

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -209,7 +209,13 @@ class Staging(object):
         self._unlink(baseline, working_copy)
         noLongerProvides(baseline, IBaseline)
         noLongerProvides(working_copy, IWorkingCopy)
-        aq_parent(aq_inner(working_copy)).manage_delObjects([working_copy.getId()])
+
+        parent = aq_parent(aq_inner(working_copy))
+        if hasattr(parent, 'manage_immediatelyDeleteObjects'):
+            # When ftw.trash is installed, immediately delete the working copy.
+            parent.manage_immediatelyDeleteObjects([working_copy.getId()])
+        else:
+            parent.manage_delObjects([working_copy.getId()])
 
     def _apply_children(self, source, target, condition=None, uuid_map=None):
         uuid_map = uuid_map or {}

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -212,9 +212,9 @@ class Staging(object):
             target_uid = getattr(source_child, '_baseline_obj_uuid', None)
             if target_uid in target_children_map:
                 target_child = target_children_map.pop(target_uid)
-                self._apply_children(source_child, target_child, uuid_map=uuid_map)
             else:
-                self._move_new_obj(source_child, target)
+                target_child = self._copy_new_obj(source_child, target)
+            self._apply_children(source_child, target_child, uuid_map=uuid_map)
 
         target.manage_delObjects(map(methodcaller('getId'), target_children_map.values()))
         return uuid_map
@@ -288,6 +288,7 @@ class Staging(object):
         for schema in getAdditionalSchemata(portal_type=portal_type):
             yield schema
 
-    def _move_new_obj(self, obj, new_parent):
-        clipboard = aq_parent(aq_inner(obj)).manage_cutObjects([obj.getId()])
-        new_parent.manage_pasteObjects(clipboard)
+    def _copy_new_obj(self, obj, new_parent):
+        clipboard = aq_parent(aq_inner(obj)).manage_copyObjects([obj.getId()])
+        info = new_parent.manage_pasteObjects(clipboard)
+        return new_parent.get(info[0]['new_id'])

--- a/ftw/simplelayout/staging/templates/baseline_viewlet.pt
+++ b/ftw/simplelayout/staging/templates/baseline_viewlet.pt
@@ -1,0 +1,21 @@
+<html xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag="python: 1"
+      i18n:domain="ftw.simplelayout">
+
+  <div class="staging-viewlet baseline"
+       tal:define="toLocalizedTime nocall:context/@@plone/toLocalizedTime">
+
+    <dl class="portalMessage warning" tal:repeat="working_copy view/get_working_copies">
+      <dt i18n:translate="" i18n:domain="plone">Warning</dt>
+      <dd i18n:translate="message_baseline">
+        <tal:creator i18n:name="owner"
+                     content="python:view.owner_name(working_copy)" />
+        is working on this page in a working copy created at
+        <tal:date i18n:name="date" content="python:toLocalizedTime(working_copy.created())" />.
+      </dd>
+    </dl>
+
+  </div>
+
+</html>

--- a/ftw/simplelayout/staging/templates/workingcopy_viewlet.pt
+++ b/ftw/simplelayout/staging/templates/workingcopy_viewlet.pt
@@ -1,0 +1,21 @@
+<html xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag="python: 1"
+      i18n:domain="ftw.simplelayout">
+
+  <div class="staging-viewlet working-copy"
+       tal:define="toLocalizedTime nocall:context/@@plone/toLocalizedTime">
+
+    <dl class="portalMessage error">
+      <dt i18n:translate="" i18n:domain="plone">Warning</dt>
+      <dd i18n:translate="message_working_copy">
+        This is the working copy of
+        <tal:creator i18n:name="owner" content="view/owner_name" />,
+        created at
+        <tal:date i18n:name="date" content="python:toLocalizedTime(context.created())" />.
+      </dd>
+    </dl>
+
+  </div>
+
+</html>

--- a/ftw/simplelayout/staging/viewlets.py
+++ b/ftw/simplelayout/staging/viewlets.py
@@ -1,0 +1,32 @@
+from ftw.simplelayout.staging.interfaces import IStaging
+from plone import api
+from plone.app.layout.viewlets import common
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+
+class WorkingCopyViewlet(common.PathBarViewlet):
+    index = ViewPageTemplateFile('templates/workingcopy_viewlet.pt')
+
+    def render(self):
+        return self.index()
+
+    @property
+    def owner_name(self):
+        owner = self.context.getOwner()
+        return owner.getProperty('fullname') or owner.getId()
+
+
+class BaselineViewlet(common.PathBarViewlet):
+    index = ViewPageTemplateFile('templates/baseline_viewlet.pt')
+
+    def render(self):
+        if api.user.is_anonymous():
+            return ''
+        return self.index()
+
+    def get_working_copies(self):
+        return IStaging(self.context).get_working_copies()
+
+    def owner_name(self, working_copy):
+        owner = working_copy.getOwner()
+        return owner.getProperty('fullname') or owner.getId()

--- a/ftw/simplelayout/tests/builders.py
+++ b/ftw/simplelayout/tests/builders.py
@@ -49,6 +49,18 @@ builder_registry.register('sl textblock', TextBlockBuilder)
 class ListingBlockBuilder(DexterityBuilder):
     portal_type = 'ftw.simplelayout.FileListingBlock'
 
+    def __init__(self, session):
+        super(ListingBlockBuilder, self).__init__(session)
+        self.children_builders = []
+
+    def with_files(self, *file_builders):
+        self.children_builders.extend(file_builders)
+        return self
+
+    def after_create(self, obj):
+        map(create, map(methodcaller('within', obj), self.children_builders))
+        return super(ListingBlockBuilder, self).after_create(obj)
+
 builder_registry.register('sl listingblock', ListingBlockBuilder)
 
 

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -1,11 +1,13 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.simplelayout.configuration import synchronize_page_config_with_blocks
 from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.simplelayout.staging.interfaces import IBaseline
 from ftw.simplelayout.staging.interfaces import IStaging
 from ftw.simplelayout.staging.interfaces import IWorkingCopy
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
 from ftw.testing import staticuid
+from plone.app.textfield.value import RichTextValue
 from plone.uuid.interfaces import IUUID
 from unittest2 import TestCase
 from zope.interface.verify import verifyObject
@@ -79,17 +81,122 @@ class TestWorkingCopy(TestCase):
                                            Builder('sl textblock').titled(u'Second')))
 
         self.assertEquals(
-            {'default': [{'cols': [{'blocks': [{'uid': 'baseline000000000000000000000002'},
-                                               {'uid': 'baseline000000000000000000000003'}]}]}]},
+            {'default': [{'cols': [{'blocks': [
+                {'uid': 'baseline000000000000000000000002'},
+                {'uid': 'baseline000000000000000000000003'}]}]}]},
             IPageConfiguration(baseline).load())
 
         with staticuid('workingcopy'):
             working_copy = IStaging(baseline).create_working_copy(self.portal)
 
         self.assertEquals(
-            {'default': [{'cols': [{'blocks': [{'uid': 'workingcopy000000000000000000001'},
-                                               {'uid': 'workingcopy000000000000000000002'}]}]}]},
+            {'default': [{'cols': [{'blocks': [
+                {'uid': 'workingcopy000000000000000000001'},
+                {'uid': 'workingcopy000000000000000000002'}]}]}]},
             IPageConfiguration(working_copy).load())
+
+    def test_apply_working_copy_copies_field_values_back_to_baseline(self):
+        bl_page = create(Builder('sl content page')
+                         .titled(u'original page title')
+                         .with_blocks(Builder('sl textblock')
+                                      .titled(u'original block title')
+                                      .having(text=RichTextValue(
+                                          u'<p>original block text</p>'))))
+
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+        wc_page.setTitle(u'modified page title')
+        wc_block = wc_page.objectValues()[0]
+        wc_block.setTitle(u'modified block title')
+        wc_block.text = RichTextValue(u'<p>modified block text</p>')
+
+        IStaging(wc_page).apply_working_copy()
+        bl_block = bl_page.objectValues()[0]
+        self.assertEquals('modified page title', wc_page.Title())
+        self.assertEquals('modified block title', bl_block.Title())
+        self.assertEquals('<p>modified block text</p>', bl_block.text.output)
+
+    def test_applying_removes_blocks_from_baseline_when_removed_in_working_copy(self):
+        bl_page = create(Builder('sl content page').titled(u'Page')
+                         .with_blocks(Builder('sl textblock').titled(u'Foo'))
+                         .with_blocks(Builder('sl textblock').titled(u'Bar')))
+        create(Builder('sl content page').titled(u'Subpage').within(bl_page))
+        self.assertEquals(['foo', 'bar', 'subpage'], bl_page.objectIds())
+
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+        self.assertEquals(['foo', 'bar'], wc_page.objectIds())
+        wc_page.manage_delObjects(['foo'])
+        self.assertEquals(['bar'], wc_page.objectIds())
+
+        IStaging(wc_page).apply_working_copy()
+        self.assertEquals(['bar', 'subpage'], bl_page.objectIds())
+
+    def test_applying_adds_new_blocks(self):
+        bl_page = create(Builder('sl content page').titled(u'Page'))
+        self.assertEquals([], bl_page.objectIds())
+
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+        create(Builder('sl textblock').titled(u'Foo').within(wc_page))
+        IStaging(wc_page).apply_working_copy()
+
+        self.assertEquals(['foo'], bl_page.objectIds())
+
+    def test_files_in_filelistingblocks_are_synced(self):
+        bl_page = create(
+            Builder('sl content page').titled(u'Page')
+            .with_blocks(Builder('sl listingblock').titled(u'Downloads')
+                         .with_files(Builder('file').titled(u'One'),
+                                     Builder('file').titled(u'Two'))))
+
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+        wc_page.downloads.one.setTitle('The first one')
+        create(Builder('file').titled(u'Three').within(wc_page.downloads))
+        wc_page.downloads.manage_delObjects(['two'])
+        IStaging(wc_page).apply_working_copy()
+
+        self.assertEquals('The first one', bl_page.downloads.one.Title())
+        self.assertEquals(['one', 'three'], bl_page.downloads.objectIds())
+
+    def test_sl_page_state_is_updated_when_applying_working_copy(self):
+        with staticuid('baseline'):
+            baseline = create(Builder('sl content page').titled(u'A page')
+                              .with_blocks(Builder('sl textblock').titled(u'First')))
+
+        self.assertEquals(
+            {'default': [{'cols': [{'blocks': [
+                {'uid': 'baseline000000000000000000000002'}]}]}]},
+            IPageConfiguration(baseline).load())
+
+        with staticuid('workingcopy'):
+            working_copy = IStaging(baseline).create_working_copy(self.portal)
+
+        self.assertEquals(
+            {'default': [{'cols': [{'blocks': [
+                {'uid': 'workingcopy000000000000000000001'}]}]}]},
+            IPageConfiguration(working_copy).load())
+
+        with staticuid('editing'):
+            create(Builder('sl textblock').titled(u'Second').within(working_copy))
+            synchronize_page_config_with_blocks(working_copy)
+
+        self.assertEquals(
+            {'default': [{'cols': [{'blocks': [
+                {'uid': 'workingcopy000000000000000000001'},
+                {'uid': 'editing0000000000000000000000001'}]}]}]},
+            IPageConfiguration(working_copy).load())
+
+        IStaging(working_copy).apply_working_copy()
+        self.assertEquals(
+            {'default': [{'cols': [{'blocks': [
+                {'uid': 'baseline000000000000000000000002'},
+                {'uid': 'editing0000000000000000000000001'}]}]}]},
+            IPageConfiguration(baseline).load())
+
+    def test_working_copy_is_removed_after_applying(self):
+        bl_page = create(Builder('sl content page').titled(u'A page'))
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+        self.assertIn(wc_page.getId(), self.portal.objectIds())
+        IStaging(wc_page).apply_working_copy()
+        self.assertNotIn(wc_page.getId(), self.portal.objectIds())
 
     def test_discard_working_copy(self):
         baseline = create(Builder('sl content page').titled(u'A page'))

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -211,7 +211,7 @@ class TestWorkingCopy(TestCase):
         self.assertEquals(
             {'default': [{'cols': [{'blocks': [
                 {'uid': 'baseline000000000000000000000002'},
-                {'uid': 'editing0000000000000000000000001'}]}]}]},
+                {'uid': 'applying000000000000000000000001'}]}]}]},
             IPageConfiguration(baseline).load())
 
     def test_sl_block_state_is_copied_when_applying(self):
@@ -274,7 +274,7 @@ class TestWorkingCopy(TestCase):
 <p>
   <a class="internal-link" href="resolveuid/baseline000000000000000000000001">One</a>
   <a class="internal-link" href="resolveuid/baseline000000000000000000000002">Two</a>
-  <a class="internal-link" href="resolveuid/editing0000000000000000000000001">Three</a>
+  <a class="internal-link" href="resolveuid/apply000000000000000000000000001">Three</a>
 </p>
         '''.strip(), bl_page.toc.text.raw.strip())
 

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -74,10 +74,13 @@ class TestWorkingCopy(TestCase):
         create(Builder('sl content page').titled(u'Child page').within(baseline))
         create(Builder('sl textblock').titled(u'Textblock').within(baseline))
         self.assertEquals({'child-page', 'textblock'}, set(baseline.objectIds()))
+        self.assertEquals(2, baseline.objectCount())
 
         working_copy = IStaging(baseline).create_working_copy(self.portal)
         self.assertEquals({'textblock'}, set(working_copy.objectIds()))
+        self.assertEquals(1, working_copy.objectCount())
         self.assertEquals({'child-page', 'textblock'}, set(baseline.objectIds()))
+        self.assertEquals(2, baseline.objectCount())
         self.assertNotEquals(IUUID(baseline['textblock']), IUUID(working_copy['textblock']))
 
     def test_UIDS_in_sl_state_are_updated_when_creating_working_copy(self):

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -315,7 +315,7 @@ class TestWorkingCopy(TestCase):
 
         browser.login().open(working_copy)
         statusmessages.assert_message(
-            'This is the working copy of test_user_1_, created at Aug 10, 2018.')
+            'This is the working copy of test_user_1_, created at Jul 24, 2017.')
 
     @browsing
     def test_message_is_displayed_on_baseline(self, browser):
@@ -327,7 +327,7 @@ class TestWorkingCopy(TestCase):
 
         browser.login().open(baseline)
         statusmessages.assert_message(
-            'test_user_1_ is working on this page in a working copy created at Aug 10, 2018.')
+            'test_user_1_ is working on this page in a working copy created at Jul 24, 2017.')
 
     def assert_staging_interfaces(self, expected, obj):
         expected = set(expected)

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -185,11 +185,13 @@ class TestWorkingCopy(TestCase):
                 {'uid': 'editing0000000000000000000000001'}]}]}]},
             IPageConfiguration(working_copy).load())
 
-        IStaging(working_copy).apply_working_copy()
+        with staticuid('applying'):
+            IStaging(working_copy).apply_working_copy()
+
         self.assertEquals(
             {'default': [{'cols': [{'blocks': [
                 {'uid': 'baseline000000000000000000000002'},
-                {'uid': 'editing0000000000000000000000001'}]}]}]},
+                {'uid': 'applying000000000000000000000001'}]}]}]},
             IPageConfiguration(baseline).load())
 
     def test_sl_block_state_is_copied_when_applying(self):

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -141,6 +141,18 @@ class TestWorkingCopy(TestCase):
 
         self.assertEquals(['foo'], bl_page.objectIds())
 
+    def test_applying_adds_new_containers_and_handles_recursion(self):
+        bl_page = create(Builder('sl content page').titled(u'Page'))
+        self.assertEquals([], bl_page.objectIds())
+
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+        gallery = create(Builder('sl galleryblock').titled(u'Pictures').within(wc_page))
+        create(Builder('image').titled('Sea').within(gallery))
+        IStaging(wc_page).apply_working_copy()
+
+        self.assertEquals(['pictures'], bl_page.objectIds())
+        self.assertEquals(['sea'], bl_page.pictures.objectIds())
+
     def test_files_in_filelistingblocks_are_synced(self):
         bl_page = create(
             Builder('sl content page').titled(u'Page')
@@ -191,7 +203,7 @@ class TestWorkingCopy(TestCase):
         self.assertEquals(
             {'default': [{'cols': [{'blocks': [
                 {'uid': 'baseline000000000000000000000002'},
-                {'uid': 'applying000000000000000000000001'}]}]}]},
+                {'uid': 'editing0000000000000000000000001'}]}]}]},
             IPageConfiguration(baseline).load())
 
     def test_sl_block_state_is_copied_when_applying(self):

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -1,0 +1,51 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.staging.interfaces import IBaseline
+from ftw.simplelayout.staging.interfaces import IStaging
+from ftw.simplelayout.staging.interfaces import IWorkingCopy
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
+from plone.uuid.interfaces import IUUID
+from unittest2 import TestCase
+from zope.interface.verify import verifyObject
+import transaction
+
+
+class TestWorkingCopy(TestCase):
+    layer = FTW_SIMPLELAYOUT_CONTENT_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_staging_manager_implements_interface(self):
+        page = create(Builder('sl content page'))
+        verifyObject(IStaging, IStaging(page))
+
+    def test_create_working_copy_of_page(self):
+        baseline = create(Builder('sl content page').titled(u'A page'))
+        self.assert_staging_interfaces((), baseline)
+        working_copy = IStaging(baseline).create_working_copy(self.portal)
+        transaction.commit()
+
+        self.assertTrue(baseline._p_oid)
+        self.assertTrue(working_copy._p_oid)
+        self.assertNotEquals(baseline._p_oid, working_copy._p_oid)
+        self.assertNotEquals(IUUID(baseline), IUUID(working_copy))
+        self.assertEquals(baseline.Title(), working_copy.Title())
+        self.assert_staging_interfaces({IBaseline}, baseline)
+        self.assert_staging_interfaces({IWorkingCopy}, working_copy)
+
+    def test_working_copy_contains_blocks_but_not_child_pages(self):
+        baseline = create(Builder('sl content page').titled(u'A page'))
+        create(Builder('sl content page').titled(u'Child page').within(baseline))
+        create(Builder('sl textblock').titled(u'Textblock').within(baseline))
+        self.assertEquals({'child-page', 'textblock'}, set(baseline.objectIds()))
+
+        working_copy = IStaging(baseline).create_working_copy(self.portal)
+        self.assertEquals({'textblock'}, set(working_copy.objectIds()))
+        self.assertEquals({'child-page', 'textblock'}, set(baseline.objectIds()))
+        self.assertNotEquals(IUUID(baseline['textblock']), IUUID(working_copy['textblock']))
+
+    def assert_staging_interfaces(self, expected, obj):
+        expected = set(expected)
+        got = set(filter(lambda iface: iface.providedBy(obj), (IBaseline, IWorkingCopy)))
+        self.assertEquals(expected, got, 'Provided interfaces unexpected for {!r}'.format(obj))

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -1,6 +1,7 @@
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.simplelayout.configuration import synchronize_page_config_with_blocks
+from ftw.simplelayout.interfaces import IBlockConfiguration
 from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.simplelayout.staging.interfaces import IBaseline
 from ftw.simplelayout.staging.interfaces import IStaging
@@ -190,6 +191,21 @@ class TestWorkingCopy(TestCase):
                 {'uid': 'baseline000000000000000000000002'},
                 {'uid': 'editing0000000000000000000000001'}]}]}]},
             IPageConfiguration(baseline).load())
+
+    def test_sl_block_state_is_copied_when_applying(self):
+        baseline = create(Builder('sl content page').titled(u'A page')
+                          .with_blocks(Builder('sl textblock').titled(u'Block')))
+        self.assertEqual({}, IBlockConfiguration(baseline.block).load())
+
+        working_copy = IStaging(baseline).create_working_copy(self.portal)
+        self.assertEqual({}, IBlockConfiguration(working_copy.block).load())
+
+        IBlockConfiguration(working_copy.block).store({'scale': 'mini'})
+        self.assertEqual({}, IBlockConfiguration(baseline.block).load())
+        self.assertEqual({'scale': 'mini'}, IBlockConfiguration(working_copy.block).load())
+
+        IStaging(working_copy).apply_working_copy()
+        self.assertEqual({'scale': 'mini'}, IBlockConfiguration(baseline.block).load())
 
     def test_working_copy_is_removed_after_applying(self):
         bl_page = create(Builder('sl content page').titled(u'A page'))

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
     'ftw.testing',
+    'ftw.trash',
     'path.py',
     'plone.app.lockingbehavior',
     'plone.app.testing',


### PR DESCRIPTION
This pull request implements a staging toolset for staging simplelayout content pages.

- This is not batteries included: the staging implementation needs to be integrated on project level, since it is usually hooked up with a workflow, which is implemented in integration code on project level.
- The working copy is created by copying the content page with all content-relevant children, but not recursively including content pages. This allows for staging of root-level pages with tons of subpages.
- The integration code can decide wether the working copy is created in-place or in a centralized folder.
- The integration code can decide wether it is possible to have multiple working copies concurrently - there is no code for handling conflicts though.
- The staging is implemented for simplelayout content pages as primary object; it therefore only supports Dexterity as primary objects. Children may be Archetypes.
- The most important types of data are support when applying the working copy to the baseline, which is:
  - field values for Dexterity and Archetypes
  - scales are purged
  - Simplelayout block state is updated
  - Simplelayout page state is updated (UUIDs; reordering blocks; changing layouts)
  - children may be added or removed
  - update references in rich text fields (UUIDs)
- Viewlets with messages are included, informing the user that the content is a baseline or a working copy.
- ``ftw.trash`` is optionally supported: when applying a working copy to the baseline, the working copy itself is permanently deleted but the blocks removed from the baseline are only trashed.