### PR TITLE
Fix image cropper styling with blueberry marketing theme.

### DIFF
--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -676,6 +676,7 @@ ul[class^="sl-toolbar"] {
       border: 1px solid;
       border-top: none;
       border-right: none;
+      z-index: 10;
       .icon {
         font-size: $font-size-h1;
         margin-right: $margin-horizontal;


### PR DESCRIPTION
Fix the image-cropper image limit validation message with the blueberry marketing theme.

The marketing theme does hide the document-first heading. Thus, the limit-validation message doesn't have enough space to display and will be overlapped by the cropping area.

Before:
<img width="591" alt="bildschirmfoto 2018-09-25 um 15 50 15" src="https://user-images.githubusercontent.com/557005/46018843-18b9ca00-c0db-11e8-87b8-7b8bb894d9c5.png">

After:
<img width="438" alt="bildschirmfoto 2018-09-25 um 15 51 06" src="https://user-images.githubusercontent.com/557005/46018851-1ce5e780-c0db-11e8-9808-2ff49f0ab277.png">
