### PR TITLE
Fix a caching issue in cropping overlay

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.22.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix a caching issue where the cropping overlay have showed the old image after uploading a new one. [elioschmutz]
 
 
 1.22.1 (2018-09-25)

--- a/ftw/simplelayout/images/cropping/browser/cropping.py
+++ b/ftw/simplelayout/images/cropping/browser/cropping.py
@@ -105,6 +105,12 @@ class ImageCroppingView(BrowserView):
     def limits(self):
         return self.image_limits.get_all_limits()
 
+    def cropping_image_src(self):
+        return '{}/@@images/image?last_modified={}'.format(
+            self.context.absolute_url(),
+            self.context.modified().strftime('%s')
+            )
+
     def _sl_block(self):
         for obj in aq_chain(self.context):
             if ISimplelayoutBlock.providedBy(obj):

--- a/ftw/simplelayout/images/cropping/browser/templates/cropping.pt
+++ b/ftw/simplelayout/images/cropping/browser/templates/cropping.pt
@@ -44,7 +44,7 @@
           </div>
           <div class="imageCropperContent">
             <tal:image condition="nocall:context/image">
-              <img class="croppingImage" tal:attributes="src string:${context/absolute_url}/@@images/image">
+              <img class="croppingImage" tal:attributes="src view/cropping_image_src">
             </tal:image>
             <tal:image condition="not:nocall:context/image">
               <span i18n:translate="">No image available</span>


### PR DESCRIPTION
Fix a caching issue where the cropping overlay have showed the old image after uploading a new one.

Before:
![screen1](https://user-images.githubusercontent.com/557005/46067377-fa091100-c176-11e8-8a7b-7f1fffd546e2.gif)


After:
![screen2](https://user-images.githubusercontent.com/557005/46067056-2ec89880-c176-11e8-9098-fb8ecf190b7a.gif)
