### PR TITLE
Add missing_value attribute to the `image_limits` and `image_cropping_aspect_ratios` interface

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.22.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add missing_value attribute to the `image_limits` and `image_cropping_aspect_ratios`
+  interfaces to prevent the form @@simplelayout-controlpanel from saving `None`
+  if no values are given. [elioschmutz]
 
 
 1.22.2 (2018-09-26)

--- a/ftw/simplelayout/interfaces.py
+++ b/ftw/simplelayout/interfaces.py
@@ -148,6 +148,7 @@ class ISimplelayoutDefaultSettings(Interface):
             u'value: soft: width=400, height=300'
             ),
         default={},
+        missing_value={},
         required=False
         )
 
@@ -169,6 +170,7 @@ class ISimplelayoutDefaultSettings(Interface):
             u'to 1.777777778 (16/9 = 1.777777778). 0 means no ratio restrictions.<br><br>'
             ),
         default={'ftw.simplelayout.TextBlock': [u'4:3 => 1.33333', u'16:9 => 1.777777778']},
+        missing_value={},
         required=False
         )
 

--- a/ftw/simplelayout/tests/test_image_configuration.py
+++ b/ftw/simplelayout/tests/test_image_configuration.py
@@ -2,6 +2,7 @@ from ftw.simplelayout.images.configuration import Configuration
 from ftw.simplelayout.interfaces import ISimplelayoutDefaultSettings
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
 from ftw.simplelayout.testing import SimplelayoutTestCase
+from ftw.testbrowser import browsing
 from plone import api
 import transaction
 
@@ -20,6 +21,16 @@ class TestImageConfigurationImageLimits(SimplelayoutTestCase):
 
     def test_format_with_no_configuration(self):
         self._set_image_limit({})
+        self.assertEqual({}, Configuration().image_limits())
+
+    @browsing
+    def test_missing_value(self, browser):
+        self._set_image_limit({})
+
+        browser.login().visit(self.layer['portal'],
+                              view='simplelayout-controlpanel')
+
+        browser.find_button_by_label('Save').click()
         self.assertEqual({}, Configuration().image_limits())
 
     def test_format_with_only_one_limit_type(self):
@@ -101,6 +112,16 @@ class TestImageConfigurationIAspectRatios(SimplelayoutTestCase):
     def test_format_with_no_configuration(self):
         self._set_aspect_rations({})
         self.assertEqual({}, Configuration().aspect_ratios())
+
+    @browsing
+    def test_missing_value(self, browser):
+        self._set_aspect_rations({})
+
+        browser.login().visit(self.layer['portal'],
+                              view='simplelayout-controlpanel')
+
+        browser.find_button_by_label('Save').click()
+        self.assertEqual({}, Configuration().image_limits())
 
     def test_format_with_aspect_ratios(self):
         self._set_aspect_rations({

--- a/ftw/simplelayout/upgrades/20181002124534_fix_missing_value_for_image_limits_and_ratios/upgrade.py
+++ b/ftw/simplelayout/upgrades/20181002124534_fix_missing_value_for_image_limits_and_ratios/upgrade.py
@@ -1,0 +1,23 @@
+from ftw.simplelayout.interfaces import ISimplelayoutDefaultSettings
+from ftw.upgrade import UpgradeStep
+from plone import api
+
+
+class FixMissingValueForImageLimitsAndRatios(UpgradeStep):
+    """Fix missing value for image limits and ratios.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()
+        self.set_default_value_for('image_limits', {})
+        self.set_default_value_for('image_cropping_aspect_ratios', {})
+
+    def set_default_value_for(self, name, value):
+        if api.portal.get_registry_record(
+                name=name, interface=ISimplelayoutDefaultSettings):
+            return
+
+        api.portal.set_registry_record(
+            name=name,
+            value=value,
+            interface=ISimplelayoutDefaultSettings)


### PR DESCRIPTION
This PR fixes the broken blocks after setting no value to `image_limits` or `image_cropping_aspect_rations`.

Before: 
![screen2](https://user-images.githubusercontent.com/557005/46344880-ea8c3b00-c642-11e8-9261-954925e18bb6.gif)


After:
![screen1](https://user-images.githubusercontent.com/557005/46344820-bc0e6000-c642-11e8-89a2-80cb569c7870.gif)


fixes: #488 