### PR TITLE
Add support for www.youtube-nocookie.com video urls.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add support for www.youtube-nocookie.com video urls. [mathias.leimgruber]
 
 
 1.23.0 (2018-10-08)

--- a/ftw/simplelayout/contenttypes/browser/templates/videoblock_youtube_nocookie.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/videoblock_youtube_nocookie.pt
@@ -1,0 +1,2 @@
+<h2 tal:content="view/block_title" tal:condition="view/block_title">Title</h2>
+<iframe tal:attributes="src view/youtbube_no_cookie_player" width="100%" height="500px" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>

--- a/ftw/simplelayout/contenttypes/browser/videoblock.py
+++ b/ftw/simplelayout/contenttypes/browser/videoblock.py
@@ -1,5 +1,6 @@
 from ftw.simplelayout.browser.blocks.base import BaseBlock
 from ftw.simplelayout.contenttypes.contents.videoblock import is_vimeo_url
+from ftw.simplelayout.contenttypes.contents.videoblock import is_youtube_nocookie_url
 from ftw.simplelayout.contenttypes.contents.videoblock import is_youtube_url
 from plone.uuid.interfaces import IUUID
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
@@ -8,11 +9,13 @@ import json
 
 
 VIMEO_PLAYER = "//player.vimeo.com/video/{0}"
+YOUTUBE_NO_COOKIE_PLAYER = 'https://www.youtube-nocookie.com/embed/{0}'
 
 
 class VideoBlockView(BaseBlock):
 
     youtube_template = ViewPageTemplateFile('templates/videoblock_youtube.pt')
+    youtube_nocookie_template = ViewPageTemplateFile('templates/videoblock_youtube_nocookie.pt')
     vimeo_template = ViewPageTemplateFile('templates/videoblock_vimeo.pt')
 
     template = None
@@ -20,6 +23,8 @@ class VideoBlockView(BaseBlock):
     def __call__(self):
         if is_youtube_url(self.context.video_url):
             self.template = self.youtube_template
+        elif is_youtube_nocookie_url(self.context.video_url):
+            self.template = self.youtube_nocookie_template
         elif is_vimeo_url(self.context.video_url):
             self.template = self.vimeo_template
         else:
@@ -38,11 +43,18 @@ class VideoBlockView(BaseBlock):
     def vimeo_player(self):
         return VIMEO_PLAYER.format(self.get_video_id())
 
+    def youtbube_no_cookie_player(self):
+        return YOUTUBE_NO_COOKIE_PLAYER.format(self.get_video_id())
+
     def get_video_id(self):
         if is_youtube_url(self.context.video_url):
             parsed_url = urlparse(self.context.video_url)
             return parsed_url.path[1:]
         elif is_vimeo_url(self.context.video_url):
+            parsed_url = urlparse(self.context.video_url)
+            path = parsed_url.path.split('/')
+            return path[-1]
+        elif is_youtube_nocookie_url(self.context.video_url):
             parsed_url = urlparse(self.context.video_url)
             path = parsed_url.path.split('/')
             return path[-1]

--- a/ftw/simplelayout/contenttypes/contents/videoblock.py
+++ b/ftw/simplelayout/contenttypes/contents/videoblock.py
@@ -25,6 +25,13 @@ def is_youtube_url(url):
     return parsed_url.netloc == 'youtu.be' and len(path) == 2 and path[-1]
 
 
+def is_youtube_nocookie_url(url):
+    # https://www.youtube-nocookie.com/embed/UUrddqT9i_s
+    parsed_url = urlparse(url)
+    path = parsed_url.path.split('/')
+    return parsed_url.netloc == 'www.youtube-nocookie.com' and len(path) == 3 and path[-1]
+
+
 class IVideoBlockSchema(form.Schema):
     """VideoBlock for simplelayout
     """
@@ -41,6 +48,7 @@ class IVideoBlockSchema(form.Schema):
     video_url = schema.URI(
         title=_(u'label_video_url', default=u'Youtube, or Vimeo URL'),
         description=_(u'Youtube format: http(s)://youtu.be/VIDEO_ID<br/>'
+                      u'Youtube (no-cookie) format: https://www.youtube-nocookie.com/embed/VIDEO_ID<br/>'
                       u'Vimeo format: http(s)://vimeo.com/(channels/groups)/'
                       u'VIDEO_ID'),
         required=True)
@@ -51,8 +59,11 @@ class IVideoBlockSchema(form.Schema):
             return
         elif is_vimeo_url(data.video_url):
             return
+        elif is_youtube_nocookie_url(data.video_url):
+            return
         else:
             raise Invalid(_(u'This is no a valid youtube, or vimeo url.'))
+
 
 alsoProvides(IVideoBlockSchema, IFormFieldProvider)
 

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -265,7 +265,7 @@ msgstr "Video"
 
 #: ./ftw/simplelayout/contenttypes/contents/videoblock.py:43
 msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
-msgstr "Youtube Format: http(s)://youtu.be/VIDEO_ID<br/>Vimeo Format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
+msgstr "Youtube Format: http(s)://youtu.be/VIDEO_ID<br/>Youtube (no-cookie) Format: https://www.youtube-nocookie.com/embed/VIDEO_ID<br/>Vimeo Format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:6

--- a/ftw/simplelayout/tests/test_videoblock.py
+++ b/ftw/simplelayout/tests/test_videoblock.py
@@ -14,6 +14,7 @@ import json
 if not IS_PLONE_5:
     from ftw.simplelayout.contenttypes.contents.videoblock import is_vimeo_url
     from ftw.simplelayout.contenttypes.contents.videoblock import is_youtube_url
+    from ftw.simplelayout.contenttypes.contents.videoblock import is_youtube_nocookie_url
 
 
 @skipUnless(not IS_PLONE_5, 'requires plone < 5')
@@ -64,6 +65,10 @@ class TestVideoValidators(TestCase):
 
         url = 'http://vimeo.com/channels/'
         self.assertFalse(is_vimeo_url(url))
+
+    def test_valid_youtube_nocookie_url(self):
+        url = 'https://www.youtube-nocookie.com/embed/UUrddqT9i_s'
+        self.assertTrue(is_youtube_nocookie_url(url))
 
 
 @skipUnless(not IS_PLONE_5, 'requires plone < 5')


### PR DESCRIPTION
- More DSGVO compatible (only 5 cookies :-D).
- As iframe - no youtplayer since that one loads a like 20 cookies.