### PR TITLE
Implement unrestricted_uuidToObject to get the infos for the staging viewlet, regardless of the workflow.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.23.1 (unreleased)
 -------------------
 
+- Implement unrestricted_uuidToObject to get the infos for the staging viewlet, regardless of the workflow. [mathias.leimgruber]
+
 - Add support for www.youtube-nocookie.com video urls. [mathias.leimgruber]
 
 

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -13,6 +13,7 @@ from ftw.simplelayout.properties import BLOCK_PROPERTIES_KEY
 from ftw.simplelayout.staging.interfaces import IBaseline
 from ftw.simplelayout.staging.interfaces import IStaging
 from ftw.simplelayout.staging.interfaces import IWorkingCopy
+from ftw.simplelayout.utils import unrestricted_uuidToObject
 from operator import methodcaller
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
@@ -93,7 +94,7 @@ class Staging(object):
         if not self.is_baseline():
             return None
 
-        return map(uuidToObject, self.context._working_copies)
+        return map(unrestricted_uuidToObject, self.context._working_copies)
 
     def create_working_copy(self, target_container):
         """Make a working copy of the adapted context into the given target container.

--- a/ftw/simplelayout/utils.py
+++ b/ftw/simplelayout/utils.py
@@ -1,5 +1,6 @@
 from ftw.simplelayout.interfaces import IBlockProperties
 from ftw.simplelayout.interfaces import ISimplelayoutBlock
+from plone import api
 from plone.dexterity.interfaces import IDexterityFTI
 from plone.dexterity.utils import safe_utf8
 from plone.i18n.normalizer.interfaces import IIDNormalizer
@@ -31,3 +32,17 @@ def get_block_types():
     return filter(
         lambda fti: ISimplelayoutBlock.__identifier__ in fti.behaviors,
         dexterity_ftis)
+
+
+def unrestricted_uuidToObject(uuid):
+    platform = getSite()
+    catalog = getToolByName(platform, 'portal_catalog', None)
+    if catalog is None:
+        return None
+
+    result = catalog.unrestrictedSearchResults(UID=uuid)
+    if len(result) != 1:
+        return None
+
+    with api.env.adopt_roles(roles=['Manager']):
+        return result[0].getObject()


### PR DESCRIPTION
- Currently it's used to get the owner of the content.
- adop_roles is not enough, since the catalog still queries with the wrong parameter
- with need both unrestrictedSearchResults and adop_roles to get the object.