### PR TITLE
Staging: fix an error where a sub page link broke staging.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Staging: fix an error which broke staging when having a link to a sub page. [jone]
 
 
 1.23.2 (2018-11-16)


### PR DESCRIPTION
If we have a textblock on the baseline with a link to a child-page of the baseline, creating a working copy of the baseline failed because:
- We are patching the _tree on the baseline when copy/pasting it as working copy.
- When pasting the working copy, plone.app.linkintegrity verifies the links, implemented as paste event handler.
- The link checker then tries to find the sub page (as the copied block has a link to the sub page) but fails, since the sub page is not in the _tree of the baseline at this moment; it will apear later again on cleanup. This results in a traversal error.

Solution:
Move reverting the _tree patch to a temporary IObjectCopiedEvent subscriber,  which is triggered right after inserting the new object. The event subscriber reverts the _tree and unregisters itself.

This solution is more error prone as the event subscriber must be registered globally (because it cannot be pickled and a savepoint is made) and thus is called by the other threads too. It is also important to make sure that the subscriber is properly removed since the global component registry is not transaction bound and thus a rollback will not clean up, leaving us with pointers to our stack locals and leading to a memory leak.