### PR TITLE
Fix ftw.trash dependency

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix ftw.trash dependency [busykoala]
 
 
 1.23.4 (2018-12-13)

--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -114,16 +114,19 @@
         handler=".handlers.modify_parent_on_block_edit"
         />
 
-    <subscriber
-        for="ftw.simplelayout.interfaces.ISimplelayoutBlock
+    <configure zcml:condition="installed ftw.trash">
+
+        <subscriber
+            for="ftw.simplelayout.interfaces.ISimplelayoutBlock
              ftw.trash.interfaces.IObjectTrashedEvent"
-        handler=".handlers.handle_trashed_and_restored_blocks"
+            handler=".handlers.handle_trashed_and_restored_blocks"
         />
 
-    <subscriber
-        for="ftw.simplelayout.interfaces.ISimplelayoutBlock
+        <subscriber
+            for="ftw.simplelayout.interfaces.ISimplelayoutBlock
              ftw.trash.interfaces.IObjectRestoredEvent"
-        handler=".handlers.handle_trashed_and_restored_blocks"
+            handler=".handlers.handle_trashed_and_restored_blocks"
         />
 
+    </configure>
 </configure>


### PR DESCRIPTION
ftw.trash was referenced even though it is not installed by default, resulting in a crash upon start.