### PR TITLE
Fix staging for Plone 5

### DIFF
--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -356,6 +356,9 @@ class Staging(object):
 
     def _copy_dx_field_values(self, source, target):
         for name, field, schemata in self._iter_fields(source.portal_type):
+            if name == 'id':
+                # never re-set the id.
+                continue
             source_storage = schemata(source)
             target_storage = schemata(target)
             value = getattr(source_storage, name)

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -25,6 +25,13 @@ class TestWorkingCopy(TestCase):
     def setUp(self):
         self.portal = self.layer['portal']
 
+        for fti in (self.portal.portal_types.File,
+                    self.portal.portal_types.Image):
+            behaviors = list(fti.behaviors)
+            behaviors.remove('plone.app.dexterity.behaviors.filename.INameFromFileName')
+            behaviors += ['plone.app.content.interfaces.INameFromTitle']
+            fti.behaviors = tuple(behaviors)
+
     def test_staging_manager_implements_interface(self):
         page = create(Builder('sl content page'))
         verifyObject(IStaging, IStaging(page))


### PR DESCRIPTION
In Plone 5, `id` is a field now that has a side effect when it is set: it is not possible to set it to the current value as it will append `-1` because the value is already in use.

Also: use the name-from-title behavior for files and images in order to maintain the same IDs as with Plone 4.