### PR TITLE
Install "ftw.referencewidget" from the master branch.

### DIFF
--- a/sources.cfg
+++ b/sources.cfg
@@ -12,4 +12,3 @@ auto-checkout =
 
 [branches]
 plonetheme.blueberry = plone51
-ftw.referencewidget = mle-plone-5.1.x


### PR DESCRIPTION
The branch "mle-plone-5.1.x" no longer exists.