### PR TITLE
Remove superfluous "for" of behavior declarations.

### DIFF
--- a/ftw/simplelayout/behaviors.zcml
+++ b/ftw/simplelayout/behaviors.zcml
@@ -33,7 +33,6 @@
         title="Hide block"
         description="Adds an option to (visually) hide a block"
         provides="ftw.simplelayout.contenttypes.behaviors.IHiddenBlock"
-        for="ftw.simplelayout.interfaces.ISimplelayoutBlock"
         />
 
 </configure>

--- a/ftw/simplelayout/images/cropping/configure.zcml
+++ b/ftw/simplelayout/images/cropping/configure.zcml
@@ -10,14 +10,12 @@
         title="Show cropped image in overlay"
         description="Allows to define if a cropped image should be used for the overlay"
         provides="ftw.simplelayout.images.cropping.behaviors.ICroppedImageInOverlay"
-        for="plone.dexterity.interfaces.IDexterityContent"
         />
 
     <plone:behavior
         title="Image cropping"
         description="Allows to crop an image and use the cropped image for display "
         provides="ftw.simplelayout.images.cropping.behaviors.IImageCropping"
-        for="plone.dexterity.interfaces.IDexterityContent"
         />
 
 </configure>


### PR DESCRIPTION
eliminates `WARNING plone.behavior Specifying 'for' in behavior 'Hide block' if no 'factory' is given has no effect and is superfluous.`