### PR TITLE
Implement dropzone upload backend.

### DIFF
--- a/ftw/simplelayout/browser/ajax/utils.py
+++ b/ftw/simplelayout/browser/ajax/utils.py
@@ -1,7 +1,52 @@
+from functools import wraps
+from zExceptions import BadRequest
+from zExceptions import Forbidden
+from zExceptions import InternalError
+from zExceptions import MethodNotAllowed
+from zExceptions import NotFound
+from zExceptions import Unauthorized
+from zope.component.hooks import getSite
 import json
+import sys
+import transaction
+
+
+class JSONRequestError(Exception):
+
+    def __init__(self, error, status_code=500):
+        self.error = error
+        self.status_code = status_code
 
 
 def json_response(request, data=None, **kwargs):
     request.response.setHeader('Content-Type', 'application/json')
     request.response.setHeader('X-Theme-Disabled', 'True')
     return json.dumps(data or kwargs)
+
+
+def json_error_responses(func):
+    def exception_response(status_code, error):
+        request = getSite().REQUEST
+        getSite().error_log.raising(sys.exc_info())
+        transaction.doom()
+        request.response.setStatus(status_code)
+        return json_response(request, error=error, proceed=False)
+
+    @wraps(func)
+    def wrapper(self, REQUEST):
+        try:
+            return func(self, REQUEST)
+        except BadRequest, exc:
+            return exception_response(400, str(exc))
+        except Unauthorized, exc:
+            return exception_response(401, str(exc))
+        except Forbidden, exc:
+            return exception_response(403, str(exc))
+        except NotFound, exc:
+            return exception_response(404, str(exc))
+        except MethodNotAllowed, exc:
+            return exception_response(405, str(exc))
+        except (InternalError, Exception), exc:
+            return exception_response(500, repr(exc))
+
+    return wrapper

--- a/ftw/simplelayout/contenttypes/browser/configure.zcml
+++ b/ftw/simplelayout/contenttypes/browser/configure.zcml
@@ -46,4 +46,18 @@
       layer="ftw.simplelayout.interfaces.ISimplelayoutLayer"
       />
 
+    <browser:page
+        for="ftw.simplelayout.contenttypes.contents.interfaces.IFileListingBlock"
+        name="dropzone-upload"
+        class=".dropzone.FileListingUpload"
+        permission="cmf.ModifyPortalContent"
+        />
+
+    <browser:page
+        for="ftw.simplelayout.contenttypes.contents.interfaces.IGalleryBlock"
+        name="dropzone-upload"
+        class=".dropzone.GalleryUpload"
+        permission="cmf.ModifyPortalContent"
+        />
+
 </configure>

--- a/ftw/simplelayout/contenttypes/browser/dropzone.py
+++ b/ftw/simplelayout/contenttypes/browser/dropzone.py
@@ -1,0 +1,80 @@
+from AccessControl.requestmethod import postonly
+from ftw.simplelayout import _
+from ftw.simplelayout.browser.ajax.utils import json_error_responses
+from ftw.simplelayout.browser.ajax.utils import json_response
+from ftw.simplelayout.utils import IS_PLONE_5
+from plone import api
+from plone.dexterity.interfaces import IDexterityFTI
+from plone.namedfile.file import NamedFile
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser import BrowserView
+from zExceptions import BadRequest
+from zope.i18n import translate
+import os.path
+
+if IS_PLONE_5:
+    from plone.namedfile.utils import getImageInfo
+else:
+    # Plone 4
+    from plone.namedfile.file import getImageInfo
+
+
+class DropzoneUploadBase(BrowserView):
+
+    @json_error_responses
+    @postonly
+    def __call__(self, REQUEST):
+        self.validate_payload()
+        obj = self.create(self.request.get('file'))
+        return self.created_response(obj)
+
+    def validate_payload(self):
+        if 'file' not in self.request.form:
+            raise BadRequest('Missing field "file".')
+
+    def created_response(self, obj):
+        self.request.response.setStatus(201)
+        return json_response(self.request,
+                             content='Created',
+                             proceed=True,
+                             url=obj.absolute_url())
+
+    def is_dexterity_fti(self, portal_type):
+        portal_types = getToolByName(self.context, 'portal_types')
+        return IDexterityFTI.providedBy(portal_types.get(portal_type))
+
+    def create_obj(self, portal_type, file_field_name, file_):
+        filename = safe_unicode(os.path.basename(file_.filename))
+        kwargs = {'container': self.context,
+                  'type': portal_type,
+                  'title': filename,
+                  'safe_id': True}
+
+        if self.is_dexterity_fti(portal_type):
+            kwargs[file_field_name] = NamedFile(file_, filename=filename)
+            return api.content.create(**kwargs)
+
+        else:
+            obj = api.content.create(**kwargs)
+            obj.Schema().getField(file_field_name).set(obj, file_)
+            obj.reindexObject(idxs=['SearchableText'])
+            return obj
+
+
+class FileListingUpload(DropzoneUploadBase):
+
+    def create(self, file_):
+        return self.create_obj('File', 'file', file_)
+
+
+class GalleryUpload(DropzoneUploadBase):
+
+    def create(self, file_):
+        content_type, width, height = getImageInfo(file_.read())
+        file_.seek(0)
+        if not content_type:
+            error = translate(_('Only images can be added to the gallery.'), context=self.request)
+            raise BadRequest(error)
+
+        return self.create_obj('Image', 'image', file_)

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-12-18 13:19+0000\n"
+"POT-Creation-Date: 2018-12-18 13:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -130,6 +130,10 @@ msgstr "Mehrere Benutzer werden mit Komma getrennt"
 #: ./ftw/simplelayout/images/cropping/browser/templates/cropping.pt:50
 msgid "No image available"
 msgstr "Kein Bild zum Bearbeiten vorhanden."
+
+#: ./ftw/simplelayout/contenttypes/browser/dropzone.py:59
+msgid "Only images can be added to the gallery."
+msgstr "Es können nur Bilder in den Galerie-Block hochgeladen werden. Dies scheint kein Bild zu sein."
 
 #: ./ftw/simplelayout/interfaces.py:116
 msgid "OpenGraph global type"
@@ -699,4 +703,3 @@ msgstr "Verwende das zugeschnittenes Bild ebenfalls für das Overlay"
 #: ./ftw/simplelayout/images/cropping/behaviors.py:18
 msgid "use_cropped_image_for_overlay_desc"
 msgstr "Wenn diese Option aktiviert ist, wird im Bild-Overlay das zugeschnittene Bild verwendet, sofern das Bild im Bildeditor zugeschnitten wurde. Deaktivieren Sie diese Option um das Originalbild im Bild-Overlay anzuzeigen."
-

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-12-18 13:19+0000\n"
+"POT-Creation-Date: 2018-12-18 13:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,6 +132,10 @@ msgstr ""
 
 #: ./ftw/simplelayout/images/cropping/browser/templates/cropping.pt:50
 msgid "No image available"
+msgstr ""
+
+#: ./ftw/simplelayout/contenttypes/browser/dropzone.py:59
+msgid "Only images can be added to the gallery."
 msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:116

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2018-12-18 13:19+0000\n"
+"POT-Creation-Date: 2018-12-18 13:22+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -132,6 +132,10 @@ msgstr ""
 
 #: ./ftw/simplelayout/images/cropping/browser/templates/cropping.pt:50
 msgid "No image available"
+msgstr ""
+
+#: ./ftw/simplelayout/contenttypes/browser/dropzone.py:59
+msgid "Only images can be added to the gallery."
 msgstr ""
 
 #: ./ftw/simplelayout/interfaces.py:116

--- a/ftw/simplelayout/testing.py
+++ b/ftw/simplelayout/testing.py
@@ -4,6 +4,7 @@ from ftw.builder.testing import set_builder_session_factory
 from ftw.simplelayout.tests import sample_types
 from ftw.simplelayout.utils import IS_PLONE_5
 from ftw.testing.layer import ComponentRegistryLayer
+from path import Path
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
 from plone.app.testing import applyProfile
@@ -113,6 +114,9 @@ class SimplelayoutTestCase(TestCase):
 
     def setup_block_views(self):
         sample_types.setup_views()
+
+    def asset(self, name):
+        return Path(__file__).joinpath('..', 'tests', 'assets', name).abspath()
 
 
 FTW_SIMPLELAYOUT_FIXTURE = FtwSimplelayoutLayer()

--- a/ftw/simplelayout/tests/assets/world.txt
+++ b/ftw/simplelayout/tests/assets/world.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/ftw/simplelayout/tests/test_dropzone_upload.py
+++ b/ftw/simplelayout/tests/test_dropzone_upload.py
@@ -1,0 +1,82 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
+from ftw.simplelayout.testing import SimplelayoutTestCase
+from ftw.simplelayout.utils import IS_PLONE_5
+from ftw.testbrowser import browser as defaultbrowser
+from ftw.testbrowser import browsing
+from plone.protect import createToken
+
+
+class TestDropZoneUpload(SimplelayoutTestCase):
+    layer = FTW_SIMPLELAYOUT_CONTENT_TESTING
+
+    @browsing
+    def test_create_files_in_filelinstingblock(self, browser):
+        listing = create(Builder('sl listingblock').titled(u'Downloads')
+                         .within(create(Builder('sl content page').titled(u'Page'))))
+        self.assertEquals([], listing.objectIds())
+
+        browser.login()
+        self.make_dropzone_upload(listing, self.asset('world.txt').open('r'))
+        self.assertEqual(201, browser.status_code)
+        self.assertEqual({u'content': u'Created',
+                          u'url': u'http://nohost/plone/page/downloads/world.txt',
+                          u'proceed': True}, browser.json)
+        self.assertEquals(['world.txt'], listing.objectIds())
+
+        doc, = listing.objectValues()
+        self.assertEquals('File', doc.portal_type)
+        self.assertEquals('world.txt', doc.Title())
+        if IS_PLONE_5:
+            self.assertEquals('Hello World', doc.file.data.strip())
+        else:
+            self.assertEquals('Hello World', doc.getFile().data.strip())
+
+    @browsing
+    def test_create_images_in_galleries(self, browser):
+        gallery = create(Builder('sl galleryblock').titled(u'Gallery')
+                         .within(create(Builder('sl content page').titled(u'Page'))))
+        self.assertEquals([], gallery.objectIds())
+
+        browser.login()
+        self.make_dropzone_upload(gallery, self.asset('cropped.jpg').open('rb'))
+        self.assertEqual(201, browser.status_code)
+        self.assertEqual({u'content': u'Created',
+                          u'url': u'http://nohost/plone/page/gallery/cropped.jpg',
+                          u'proceed': True}, browser.json)
+        self.assertEquals(['cropped.jpg'], gallery.objectIds())
+
+        img, = gallery.objectValues()
+        self.assertEquals('Image', img.portal_type)
+        self.assertEquals('cropped.jpg', img.Title())
+
+    @browsing
+    def test_files_are_not_allowed_in_galleries(self, browser):
+        gallery = create(Builder('sl galleryblock').titled(u'Gallery')
+                         .within(create(Builder('sl content page').titled(u'Page'))))
+        self.assertEquals([], gallery.objectIds())
+
+        with browser.login().expect_http_error(400):
+            self.make_dropzone_upload(gallery, self.asset('world.txt').open('r'))
+
+        self.assertEqual({u'error': u'Only images can be added to the gallery.',
+                          u'proceed': False}, browser.json)
+        self.assertEquals([], gallery.objectIds())
+
+    def make_dropzone_upload(self, context, file_):
+        """The dropzone JS makes a multipart upload with the the file as field named "file".
+        The testbrowser does not support making multipart requests directly (we would have to
+        create the MIME body ourself), but the form filling does that well.
+        Therefore we use an HTML form for uploading.
+        """
+        html = (
+            '<form action="{}/@@dropzone-upload" method="post" enctype="multipart/form-data">'
+            '  <input type="file" name="file" />'
+            '  <input type="hidden" name="_authenticator" value="{}" />'
+            '  <input type="submit" />'
+            '</form>').format(context.absolute_url(), createToken())
+
+        defaultbrowser.open(context).parse(html)
+        defaultbrowser.fill({'file': file_}).submit()
+        return defaultbrowser


### PR DESCRIPTION
The @@dropzone-upload is implemented for file listing blocks and gallery blocks. It expects a MIME multipart request with a "file" and the normal CSRF authenticator token. In file listing blocks it creates a "File", in galleries it creates an "Image" (if the uploaded file is of an image type).