### PR TITLE
Fix tests by downgrading collective.geo packages.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -8,4 +8,5 @@ test-egg = ftw.simplelayout [tests, contenttypes, mapblock]
 
 [versions]
 six = 1.9.0
-
+collective.geo.openlayers = <4a
+collective.geo.mapwidget = <3a


### PR DESCRIPTION
The newer versions of collective.geo packages seem incompatible with Plone 4.