### PR TITLE
Test for plone.app.multilingual supported staging

### DIFF
--- a/ftw/simplelayout/tests/test_pam_staging.py
+++ b/ftw/simplelayout/tests/test_pam_staging.py
@@ -1,0 +1,20 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.simplelayout.staging.interfaces import IStaging
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_PAM_TESTING
+from unittest2 import TestCase
+
+
+class TestPloneAppMultilingualStagingSupport(TestCase):
+    layer = FTW_SIMPLELAYOUT_CONTENT_PAM_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test(self):
+        baseline = create(Builder('sl content page').titled(u'A page'))
+        create(Builder('sl textblock').within(baseline))
+        self.assertFalse(IStaging(baseline).is_baseline())
+        working_copy = IStaging(baseline).create_working_copy(self.portal)
+        self.assertTrue(IStaging(baseline).is_baseline())
+        self.assertFalse(IStaging(working_copy).is_baseline())

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ tests_require = [
     'transaction',
     'unittest2',
     'zope.configuration',
-    'ftw.simplelayout [trash, mapblock]',
+    'ftw.simplelayout [trash, mapblock, pam]',
 ]
 
 extras_require = {
@@ -35,7 +35,10 @@ extras_require = {
     ],
     'trash': [
         'ftw.trash',
-    ]
+    ],
+    'pam': [
+        'plone.app.multilingual >=2.0.4, <3a',
+    ],
 }
 
 


### PR DESCRIPTION
Adds a test for proving that plone.app.multilingual is supported.

The currently released version `plone.app.multilingual = 2.0.3` does not work well with our staging; see #496.

The branch `2.x` works though, because the change https://github.com/plone/plone.app.multilingual/commit/2f4a8e95f4dd54ea5faa33879241fa1ec5a6808a fixes the issue.