### PR TITLE
Fix plone 4 build by pinning collective.z3cform.datagridfield to 1.4.0.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix plone 4 build by pinning collective.z3cform.datagridfield to 1.4.0. [mathias.leimgruber]
 
 
 2.0.1 (2019-03-08)

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -18,3 +18,4 @@ collective.geo.openlayers = 3.2b1
 collective.geo.settings = 3.1
 collective.z3cform.colorpicker = 1.4
 collective.z3cform.mapwidget = 2.1
+collective.z3cform.datagridfield = 1.4.0


### PR DESCRIPTION
A new release from collective.z3cform.datagridfield (1.5.0) has been cut. This one is no longer Plone 4 compatible. 