### PR TITLE
Revert commit removing IReferenceable and add tests

### DIFF
--- a/ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.ContentPage.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.ContentPage.xml
@@ -36,6 +36,7 @@
         <element value="collective.dexteritytextindexer.behavior.IDexterityTextIndexer" />
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="plone.app.dexterity.behaviors.metadata.IBasic" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.FileListingBlock.xml
@@ -29,6 +29,7 @@
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
         <element value="ftw.simplelayout.contenttypes.behaviors.IHiddenBlock"/>
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.GalleryBlock.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.GalleryBlock.xml
@@ -29,6 +29,7 @@
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
         <element value="ftw.simplelayout.contenttypes.behaviors.IHiddenBlock"/>
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->

--- a/ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.VideoBlock.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default/types/ftw.simplelayout.VideoBlock.xml
@@ -26,6 +26,7 @@
     <property name="behaviors">
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
+        <element value="plone.app.referenceablebehavior.referenceable.IReferenceable"/>
     </property>
 
     <!-- View information -->


### PR DESCRIPTION
The commit `abc8` mistakenly removed IReferenceable in plone4. In consequence references were not added to the reference catalog. This adds it again plus a test showing that it is working again.