### PR TITLE
Add changelog for adding IReferenceable

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Fix JavaScript of the map block. [mbaechtold]
 
+- Revert: Commit abc8 mistakenly removed IReferencable [busykoala]
+
 - Staging: remove auto generated children when creating a working copy. [jone]
 
 - Staging: Add link to working copies in warning message. [mathias.leimgruber]


### PR DESCRIPTION
I forgot to add the changelog in https://github.com/4teamwork/ftw.simplelayout/pull/526

This adds a changelog for the reverted abc8.