### PR TITLE
Fix mapblock.js

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 2.0.2 (unreleased)
 ------------------
 
+- Fix JavaScript of the map block. [mbaechtold]
+
 - Staging: remove auto generated children when creating a working copy. [jone]
 
 - Staging: Add link to working copies in warning message. [mathias.leimgruber]

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -66,62 +66,62 @@
 
     });
 
-    $(document).on("onLoad", ".overlay", function() {
+    function initEdit(mapWidgets) {
 
-      function initEdit(mapWidgets) {
-
-        if (mapWidgets.length === 0) {
-          return;
-        }
-
-        mapWidgets.collectivegeo();
-        mapWidgets.collectivegeo("add_edit_layer");
-        mapWidgets.collectivegeo("add_geocoder");
-
-        var ol_map = mapWidgets.data('collectivegeo').mapwidget.map;
-        ol_map.events.register('zoomend', ol_map, function(event){
-          var zoom = event.object.zoom;
-          var zoomField = $('#form-widgets-zoomlevel');
-
-          if (zoomField !== undefined) {
-            zoomField.val(zoom);
-          }
-        });
-
-        ol_map.events.register('changebaselayer', ol_map, function(event){
-          var layer = event.object.baseLayer.name;
-          var layerField = $('#form-widgets-maplayer');
-          if (layerField !== undefined) {
-            layerField.val(layer);
-          }
-        });
-
-        // Fix mouse pointer position according to openlayers pointer
-        $(mapWidgets.closest(".pb-ajax")).on("scroll", function(){
-          mapWidgets.collectivegeo("refresh");
-        });
+      if (mapWidgets.length === 0) {
+        return;
       }
 
-      window.MapBlockEditInitializer = function() {
-        if ($.fn.collectivegeo) {
-          var mapWidgets = $(".map-widget .blockwidget-cgmap").filter(":visible");
-          initEdit(mapWidgets);
+      mapWidgets.collectivegeo();
+      mapWidgets.collectivegeo("add_edit_layer");
+      mapWidgets.collectivegeo("add_geocoder");
 
-          if (mapWidgets.data('collectivegeo') === undefined) {
-            // No widget initialized
-            // Get hidden maps (maps with no size yet)
-            if ($('.blockwidget-cgmap').filter(':hidden').length > 0) {
-                var tabs = $('select.formTabs, ul.formTabs');
-                tabs.bind("onClick", function (e, index) {
-                  initGoogleMaps();
-                  var curpanel = $(this).data('tabs').getCurrentPane();
-                  initEdit(curpanel.find('.blockwidget-cgmap'));
-                });
-            }
-            return;
-          }
+      var ol_map = mapWidgets.data('collectivegeo').mapwidget.map;
+      ol_map.events.register('zoomend', ol_map, function(event){
+        var zoom = event.object.zoom;
+        var zoomField = $('#form-widgets-zoomlevel');
+
+        if (zoomField !== undefined) {
+          zoomField.val(zoom);
         }
-      };
+      });
+
+      ol_map.events.register('changebaselayer', ol_map, function(event){
+        var layer = event.object.baseLayer.name;
+        var layerField = $('#form-widgets-maplayer');
+        if (layerField !== undefined) {
+          layerField.val(layer);
+        }
+      });
+
+      // Fix mouse pointer position according to openlayers pointer
+      $(mapWidgets.closest(".pb-ajax")).on("scroll", function(){
+        mapWidgets.collectivegeo("refresh");
+      });
+    }
+
+    window.MapBlockEditInitializer = function() {
+      if ($.fn.collectivegeo) {
+        var mapWidgets = $(".map-widget .blockwidget-cgmap").filter(":visible");
+        initEdit(mapWidgets);
+
+        if (mapWidgets.data('collectivegeo') === undefined) {
+          // No widget initialized
+          // Get hidden maps (maps with no size yet)
+          if ($('.blockwidget-cgmap').filter(':hidden').length > 0) {
+              var tabs = $('select.formTabs, ul.formTabs');
+              tabs.bind("onClick", function (e, index) {
+                initGoogleMaps();
+                var curpanel = $(this).data('tabs').getCurrentPane();
+                initEdit(curpanel.find('.blockwidget-cgmap'));
+              });
+          }
+          return;
+        }
+      }
+    };
+
+    $(document).on("onLoad", ".overlay", function() {
 
       if (typeof google === 'object' && typeof google.maps === 'object'){
         window.MapBlockEditInitializer();

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -29,10 +29,6 @@
     }
   };
 
-  $(window).on('load', function(){
-    initGoogleMaps();
-  });
-
   $(document).on('blockMoved', function(event, data){
     var map = data.element.find('.blockwidget-cgmap');
     setMapHeight(map);
@@ -131,5 +127,11 @@
 
     });
   });
+
+  $(window).on('load', function(){
+    initGoogleMaps();
+    window.MapBlockEditInitializer();
+  });
+
 })();
 

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -2,42 +2,42 @@
 
   "use strict";
 
-    var setMapHeight = function(maps){
-      maps.each(function(index, map){
-        $(map).css('height', $(map).width() / 3 * 2);
-      });
-    };
+  var setMapHeight = function(maps){
+    maps.each(function(index, map){
+      $(map).css('height', $(map).width() / 3 * 2);
+    });
+  };
 
-    var initGoogleMaps = function(callback){
-      var widget = $('.blockwidget-cgmap, .map-widget');
-      if (widget.length > 0) {
-        var googleJS = widget.data('googlejs');
-        if (callback !== undefined) {
-          $.getScript(googleJS + '&callback=' + callback);
+  var initGoogleMaps = function(callback){
+    var widget = $('.blockwidget-cgmap, .map-widget');
+    if (widget.length > 0) {
+      var googleJS = widget.data('googlejs');
+      if (callback !== undefined) {
+        $.getScript(googleJS + '&callback=' + callback);
 
-        } else {
-          $.getScript(googleJS, function(){
-            if ($.fn.collectivegeo) {
-              var maps = $(".blockwidget-cgmap").filter(":visible");
+      } else {
+        $.getScript(googleJS, function(){
+          if ($.fn.collectivegeo) {
+            var maps = $(".blockwidget-cgmap").filter(":visible");
 
-              setMapHeight(maps);
-              maps.collectivegeo();
-            }
+            setMapHeight(maps);
+            maps.collectivegeo();
+          }
 
-          });
-        }
+        });
       }
-    };
+    }
+  };
 
-    $(window).on('load', function(){
-      initGoogleMaps();
-    });
+  $(window).on('load', function(){
+    initGoogleMaps();
+  });
 
-    $(document).on('blockMoved', function(event, data){
-      var map = data.element.find('.blockwidget-cgmap');
-      setMapHeight(map);
-      map.collectivegeo('refresh');
-    });
+  $(document).on('blockMoved', function(event, data){
+    var map = data.element.find('.blockwidget-cgmap');
+    setMapHeight(map);
+    map.collectivegeo('refresh');
+  });
 
 
   $(function() {


### PR DESCRIPTION
This fixes a problem in `ftw.addressblock` (which is based on the JavaScript of the map block): until now, the map did not load when editing the address block directly (not in the overlay, but in the tab of the edit view of the address block itself).