### PR TITLE
Allow map preferences for behaviours

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Add macros and slots to block views for easy customization. [jone]
+- Include map preferences behaviours in mapblock.js [Nachtalb]
 
 
 2.0.2 (2019-05-17)

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -75,7 +75,7 @@
       var ol_map = mapWidgets.data('collectivegeo').mapwidget.map;
       ol_map.events.register('zoomend', ol_map, function(event){
         var zoom = event.object.zoom;
-        var zoomField = $('#form-widgets-zoomlevel');
+        var zoomField = $('[id^=form-widgets][id$=-zoomlevel]');
 
         if (zoomField !== undefined) {
           zoomField.val(zoom);
@@ -84,7 +84,8 @@
 
       ol_map.events.register('changebaselayer', ol_map, function(event){
         var layer = event.object.baseLayer.name;
-        var layerField = $('#form-widgets-maplayer');
+        var layerField = $('[id^=form-widgets][id$=-maplayer]');
+
         if (layerField !== undefined) {
           layerField.val(layer);
         }


### PR DESCRIPTION
This will be used for ftw.addressblock to work correctly.
The selector looks for an id starting with `field-widget` because otherwise, it would also select the widgets wrapper div. To get the zoomlevel / maplayer we filter for ending with. Together with the starting filter, we can get all zoomlevel / maplayer widgets from or not from a behaviour.

This is in conjunction with https://github.com/4teamwork/ftw.addressblock/pull/25