### PR TITLE
Add macros and slots to block views for easy customization.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add macros and slots to block views for easy customization. [jone]
 
 
 2.0.2 (2019-05-17)

--- a/ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt
@@ -1,35 +1,48 @@
 <html xmlns:tal="http://xml.zope.org/namespaces/tal"
-	  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-	  tal:omit-tag="python: 1"
-	  i18n:domain="ftw.simplelayout">
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag="python: 1"
+      i18n:domain="ftw.simplelayout">
+  <metal:MAIN define-macro="main">
 
-	<h2 tal:content="view/block_title" tal:condition="view/block_title">Title</h2>
 
-    <span class="dropzonewrapper"
-         tal:condition="view/can_add">
+    <metal:TITLE define-slot="title">
+      <h2 tal:content="view/block_title" tal:condition="view/block_title">Title</h2>
+    </metal:TITLE>
+
+
+    <metal:DROPZONE define-slot="dropzone">
+      <span class="dropzonewrapper"
+            tal:condition="view/can_add">
         <div class="filedropzone"
              tal:attributes="data-endpoint string:${here/absolute_url}/dropzone-upload;
                              data-type string:File">
-            <div class="dz-message" data-dz-message><span i18n:translate="">Upload files here</span></div>
+          <div class="dz-message" data-dz-message><span i18n:translate="">Upload files here</span></div>
         </div>
         <button class="upload">Upload</button>
-    </span>
+      </span>
+    </metal:DROPZONE>
 
-    <p tal:condition="python: view.can_add and not view.get_images()"
-     i18n:translate="">This block is empty.</p>
 
-	<tal:boxes repeat="img view/get_images">
+    <metal:BODY define-slot="body">
+      <p tal:condition="python: view.can_add and not view.get_images()"
+         i18n:translate="">This block is empty.</p>
 
-		<div class="galleryblockImageWrapper">
-			<a class="colorboxLink" href="#"
-				tal:attributes="
-					title img/title_or_id;
-					rel string:colorbox-${here/getId};
-					href python: view.get_full_image_scale(img)">
-                <img tal:replace="structure python: view.get_image_scale_tag(img)" />
-			</a>
-		</div>
+      <tal:boxes repeat="img view/get_images">
 
-	</tal:boxes>
+        <div class="galleryblockImageWrapper">
+          <a class="colorboxLink" href="#"
+             tal:attributes="
+                             title img/title_or_id;
+                             rel string:colorbox-${here/getId};
+                             href python: view.get_full_image_scale(img)">
+            <img tal:replace="structure python: view.get_image_scale_tag(img)" />
+          </a>
+        </div>
 
+      </tal:boxes>
+    </metal:BODY>
+
+
+  </metal:MAIN>
 </html>

--- a/ftw/simplelayout/contenttypes/browser/templates/listingblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/listingblock.pt
@@ -1,25 +1,36 @@
 <html xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       tal:omit-tag="python: 1"
       i18n:domain="ftw.simplelayout">
-
-    <h2 tal:content="view/block_title"
-        tal:condition="view/block_title" />
+  <metal:MAIN define-macro="main">
 
 
-    <div class="dropzonewrapper"
-         tal:condition="view/can_add">
+    <metal:TITLE define-slot="title">
+      <h2 tal:content="view/block_title"
+          tal:condition="view/block_title" />
+    </metal:TITLE>
+
+
+    <metal:DROPZONE define-slot="dropzone">
+      <div class="dropzonewrapper"
+           tal:condition="view/can_add">
         <div class="filedropzone"
              tal:attributes="data-endpoint string:${here/absolute_url}/dropzone-upload;
                              data-type string:File">
-            <div class="dz-message" data-dz-message><span i18n:translate="">Dateien hier hochladen</span></div>
+          <div class="dz-message" data-dz-message><span i18n:translate="">Dateien hier hochladen</span></div>
         </div>
         <button class="upload">Upload</button>
-    </div>
+      </div>
+    </metal:DROPZONE>
 
 
-    <div tal:replace="structure view/render_table" />
-    <p tal:condition="python: view.can_add and not view.get_table_contents()"
-     i18n:translate="">This block is empty.</p>
+    <metal:BODY define-slot="body">
+      <div tal:replace="structure view/render_table" />
+      <p tal:condition="python: view.can_add and not view.get_table_contents()"
+         i18n:translate="">This block is empty.</p>
+    </metal:BODY>
 
+
+  </metal:MAIN>
 </html>

--- a/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
@@ -1,20 +1,27 @@
 <html xmlns:tal="http://xml.zope.org/namespaces/tal"
-  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-  tal:omit-tag="python: 1"
-  tal:define="teaser_url view/teaser_url;
-              image view/get_image_data"
-  i18n:domain="ftw.simplelayout">
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      tal:omit-tag="python: 1"
+      i18n:domain="ftw.simplelayout">
+  <metal:MAIN define-macro="main">
 
-  <h2 tal:condition="view/block_title">
-      <a tal:attributes="href teaser_url;
-                         title view/block_title"
-         tal:content="view/block_title"
-         tal:omit-tag="not:teaser_url">Title</a>
-  </h2>
 
-  <tal:image tal:condition="image">
-    <div tal:attributes="class image/wrapper_css_classes">
-        <div class="imageContainer">
+    <metal:TITLE define-slot="title">
+      <h2 tal:define="teaser_url view/teaser_url"
+          tal:condition="view/block_title">
+        <a tal:attributes="href teaser_url;
+                           title view/block_title"
+           tal:content="view/block_title"
+           tal:omit-tag="not:teaser_url">Title</a>
+      </h2>
+    </metal:TITLE>
+
+
+    <metal:BODY define-slot="body">
+      <tal:image tal:define="image view/get_image_data"
+                 tal:condition="image">
+        <div tal:attributes="class image/wrapper_css_classes">
+          <div class="imageContainer">
             <tal:block condition="view/show_limit_indicator">
               <div tal:content="structure context/@@limit_indicator"></div>
             </tal:block>
@@ -23,15 +30,18 @@
                                title image/link_title;
                                data-caption context/image_caption;
                                class image/link_css_classes">
-                <img tal:replace="structure image/image_tag" />
+              <img tal:replace="structure image/image_tag" />
             </a>
+          </div>
+          <div class="hiddenStructure" i18n:translate="hidden_label_image_caption">Image caption:</div>
+          <div class="image-caption" tal:content="context/image_caption" />
         </div>
-        <div class="hiddenStructure" i18n:translate="hidden_label_image_caption">Image caption:</div>
-        <div class="image-caption" tal:content="context/image_caption" />
-    </div>
-  </tal:image>
-  <div tal:replace="structure here/text/output | nothing" />
-  <p tal:condition="python: view.can_add and not (here.image or here.text or here.title)"
-     i18n:translate="">This block is empty.</p>
+      </tal:image>
+      <div tal:replace="structure here/text/output | nothing" />
+      <p tal:condition="python: view.can_add and not (here.image or here.text or here.title)"
+         i18n:translate="">This block is empty.</p>
+    </metal:BODY>
 
+
+  </metal:MAIN>
 </html>


### PR DESCRIPTION
Using macros and slots allow for easy customization:

- the templates now define a `main` macro
- the templates now define slots such as `title`, `dropzone`, `body`

We'll use that for customizing the title in `ftw.book`.