### PR TITLE
Fix mapblock.js for plone 5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix mapblock.js compatibility with plone5 [Nachtalb]
 
 
 2.1.0 (2019-05-21)

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -106,10 +106,12 @@
           // No widget initialized
           // Get hidden maps (maps with no size yet)
           if ($('.blockwidget-cgmap').filter(':hidden').length > 0) {
-              var tabs = $('select.formTabs, ul.formTabs');
+              var tabs = $('form.autotabs .autotoc-level-1, select.formTabs, ul.formTabs');
               tabs.bind("onClick", function (e, index) {
                 initGoogleMaps();
-                var curpanel = $(this).data('tabs').getCurrentPane();
+                var curpanel = $(this).parents('form').find('.autotoc-section.active');
+                if (curpanel.length === 0)
+                  curpanel = $(this).data('tabs').getCurrentPane();
                 initEdit(curpanel.find('.blockwidget-cgmap'));
               });
           }


### PR DESCRIPTION
On plone 5 we don't have the same tab structure in forms as in plone 4 anymore. This lead the mapblock to not initialising the map when clicking on a tab. To fix this we use new selectors for plone 5 and fallback to plone 4 selectors if no tabs could be found.