### PR TITLE
Fix html entities in data-googlejs url.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,8 @@ Changelog
 
 - Move contenttypes js to resource bundles. [busykoala]
 
+- Fix html entities in data-googlejs url [mathias.leimgruber]
+
 
 2.1.0 (2019-05-21)
 ------------------

--- a/ftw/simplelayout/mapblock/browser/templates/map_input.pt
+++ b/ftw/simplelayout/mapblock/browser/templates/map_input.pt
@@ -8,7 +8,7 @@
     tal:define="cgmap view/cgmap;
                 mapid cgmap/mapid;
                 geosettings python:context.restrictedTraverse('@@geosettings-view');"
-        tal:attributes="data-googlejs string:${geosettings/google_maps_js};">
+        tal:attributes="data-googlejs geosettings/google_maps_js">
 
     <metal:use use-macro="context/@@collectivegeo-macros/geocoding"/>
 
@@ -21,7 +21,7 @@
       <div id="map" class="blockwidget-cgmap"
            tal:attributes="id mapid;
               style context/@@collectivegeo-macros/map_inline_css;
-              data-googlejs string:${geosettings/google_maps_js};
+              data-googlejs geosettings/google_maps_js;
               data-cgeolatitude map_defaults/latitude|nothing;
               data-cgeolongitude map_defaults/longitude|nothing;
               data-cgeozoom map_defaults/zoom|nothing;


### PR DESCRIPTION
The string expression results in having a `&amp;` in the url right before the api key argument, which themselves results having no api key delivered to google maps. 

<img width="999" alt="Screen Shot 2019-06-14 at 11 42 05" src="https://user-images.githubusercontent.com/437933/59500336-83917800-8e99-11e9-8b8d-126226865b75.png">


- Tested with plone 4.3 (no Chameleon)
- Tested with plone 5.1.5 Chameleon 2.25
- Tested with plone 5.1.5 Chameleon 3.3