### PR TITLE
Fix a tag anchor retrieval

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.11 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix a tag anchor retrieval [Nachtalb]
 
 
 1.23.10 (2019-05-21)

--- a/ftw/simplelayout/browser/anchors.py
+++ b/ftw/simplelayout/browser/anchors.py
@@ -7,8 +7,7 @@ from Products.Five.browser import BrowserView
 from zope.interface import implements
 from zope.schema import getFieldsInOrder
 
-
-SEARCHPATTERN = "a"
+SEARCHPATTERN = "//a[@name]/@name"
 
 
 class BlockAnchorsView(BrowserView):
@@ -50,7 +49,4 @@ class BlockAnchorsView(BrowserView):
         if not text:
             return []
         tree = fromstring(text)
-        return [
-            anchor.get('name') for anchor in tree.findall(SEARCHPATTERN)
-            if "name" in anchor.keys()
-        ]
+        return tree.xpath(SEARCHPATTERN)


### PR DESCRIPTION
In some cases it was not possible for the current implementation to get
the anchors. With this implementation it is more explicit about the
anchors and is more robust.