### PR TITLE
Fix click event not caught on plone 5 due to preventation through plone.mockup

### DIFF
--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -107,7 +107,7 @@
           // Get hidden maps (maps with no size yet)
           if ($('.blockwidget-cgmap').filter(':hidden').length > 0) {
               var tabs = $('form.autotabs .autotoc-level-1, select.formTabs, ul.formTabs');
-              tabs.bind("onClick", function (e, index) {
+              tabs.bind("mouseup", function (e, index) {
                 initGoogleMaps();
                 var curpanel = $(this).parents('form').find('.autotoc-section.active');
                 if (curpanel.length === 0)


### PR DESCRIPTION
The JS which handles the tabs in edit forms and so on stops the
propagation of the click event. So as an alternative we use the `mouseup`
event, which is fired after the click and is not prevented by plone.

This is a part of https://github.com/4teamwork/ftw.simplelayout/pull/535