### PR TITLE
 Galleryblock: show image description as caption.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Fix a tag anchor retrieval [Nachtalb]
 
+- Galleryblock: show image description as caption. [mathias.leimgruber]
+
 
 1.23.10 (2019-05-21)
 --------------------

--- a/ftw/simplelayout/contenttypes/browser/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/browser/galleryblock.py
@@ -74,6 +74,11 @@ class GalleryBlockView(BaseBlock):
             alt=self.generate_image_alttext(img),
         )
 
+    def get_image_caption(self, img):
+        if getattr(self.context, 'show_legend', True):
+            return img.Description()
+        return ''
+
     def _get_fallback_image_scale(self):
         current_folder = os.path.dirname(__file__)
 

--- a/ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/galleryblock.pt
@@ -15,7 +15,8 @@
 				tal:attributes="
 					title img/title_or_id;
 					rel string:colorbox-${here/getId};
-					href python: view.get_full_image_scale(img)">
+					href python: view.get_full_image_scale(img);
+                    data-caption python: view.get_image_caption(img)">
                 <img tal:replace="structure python: view.get_image_scale_tag(img)" />
 			</a>
 		</div>

--- a/ftw/simplelayout/contenttypes/contents/galleryblock.py
+++ b/ftw/simplelayout/contenttypes/contents/galleryblock.py
@@ -65,6 +65,11 @@ class IGalleryBlockSchema(form.Schema):
         default="ascending",
         vocabulary=sort_order_vocabulary)
 
+    show_legend = schema.Bool(
+        title=_(u'label_legend', default=u'Show description of images as legend'),
+        default=True,
+        required=False)
+
 
 alsoProvides(IGalleryBlockSchema, IFormFieldProvider)
 

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-23 12:14+0000\n"
+"POT-Creation-Date: 2019-07-23 15:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -510,7 +510,7 @@ msgid "label_folder_contents_files"
 msgstr "Dateien über Inhalte verwalten."
 
 #. Default: "Go to folder contents for managing images"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:90
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:95
 msgid "label_folder_contents_images"
 msgstr "Bilder über Inhalte verwalten."
 
@@ -573,6 +573,11 @@ msgstr "25% - 75% Verteilung"
 #: ./ftw/simplelayout/browser/ajax/toolbox_view.py:88
 msgid "label_layout_inverse"
 msgstr "Umkehren / Spiegeln"
+
+#. Default: "Show description of images as legend"
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:69
+msgid "label_legend"
+msgstr "Beschreibung der Bilder als Legende in der Grossansicht verwenden"
 
 #. Default: "Modification date"
 #: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:23
@@ -639,7 +644,7 @@ msgstr "Titel"
 
 #. Default: "Upload"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:170
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:83
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:88
 msgid "label_upload"
 msgstr "Datei hochladen"
 

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-23 12:14+0000\n"
+"POT-Creation-Date: 2019-07-23 15:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -513,7 +513,7 @@ msgid "label_folder_contents_files"
 msgstr ""
 
 #. Default: "Go to folder contents for managing images"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:90
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:95
 msgid "label_folder_contents_images"
 msgstr ""
 
@@ -575,6 +575,11 @@ msgstr ""
 #. Default: "Invert layout"
 #: ./ftw/simplelayout/browser/ajax/toolbox_view.py:88
 msgid "label_layout_inverse"
+msgstr ""
+
+#. Default: "Show description of images as legend"
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:69
+msgid "label_legend"
 msgstr ""
 
 #. Default: "Modification date"
@@ -642,12 +647,12 @@ msgstr ""
 
 #. Default: "Upload"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:170
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:83
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:88
 msgid "label_upload"
 msgstr ""
 
 #. Default: "Youtube, or Vimeo URL"
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:42
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:49
 msgid "label_video_url"
 msgstr ""
 

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-04-23 12:14+0000\n"
+"POT-Creation-Date: 2019-07-23 15:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -513,7 +513,7 @@ msgid "label_folder_contents_files"
 msgstr ""
 
 #. Default: "Go to folder contents for managing images"
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:90
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:95
 msgid "label_folder_contents_images"
 msgstr ""
 
@@ -575,6 +575,11 @@ msgstr ""
 #. Default: "Invert layout"
 #: ./ftw/simplelayout/browser/ajax/toolbox_view.py:88
 msgid "label_layout_inverse"
+msgstr ""
+
+#. Default: "Show description of images as legend"
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:69
+msgid "label_legend"
 msgstr ""
 
 #. Default: "Modification date"
@@ -642,12 +647,12 @@ msgstr ""
 
 #. Default: "Upload"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:170
-#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:83
+#: ./ftw/simplelayout/contenttypes/contents/galleryblock.py:88
 msgid "label_upload"
 msgstr ""
 
 #. Default: "Youtube, or Vimeo URL"
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:42
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:49
 msgid "label_video_url"
 msgstr ""
 


### PR DESCRIPTION
- A new option is given to the user, whether the description of the image is used a caption in the overlay or not. 
- The option is enabled by default
- If there's no description and the option is enable it falls back to the old implementation (shows the alt text of the image as caption in the overlay.

<img width="1215" alt="Screen Shot 2019-07-23 at 17 24 55" src="https://user-images.githubusercontent.com/437933/61725204-9ee08480-ad6f-11e9-9a28-0d4958060220.png">
<img width="1217" alt="Screen Shot 2019-07-23 at 17 24 43" src="https://user-images.githubusercontent.com/437933/61725205-9ee08480-ad6f-11e9-93cb-333d538241bf.png">
