### PR TITLE
Backport 2.x -> 1.x: #541 from ne/preserver-order-in-working-copy

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.12 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Preserve childrens children order when applying working copies [Nachtalb]
 
 
 1.23.11 (2019-07-25)

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -297,6 +297,7 @@ class Staging(object):
                 target_child = self._copy_new_obj(source_child, target)
                 uuid_map[IUUID(source_child)] = IUUID(target_child)
 
+        target.moveObjectsToTop(source.objectIds())
         target.manage_delObjects(map(methodcaller('getId'), target_children_map.values()))
         return uuid_map
 

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -185,6 +185,35 @@ class TestWorkingCopy(TestCase):
         self.assertEquals('The first one', bl_page.downloads.one.Title())
         self.assertEquals(['one', 'three'], bl_page.downloads.objectIds())
 
+    def test_childrens_children_order_is_preserved(self):
+        bl_page = create(Builder('sl content page').titled(u'Page'))
+        bl_dow = create(Builder('sl listingblock').titled(u'Downloads')
+                        .within(bl_page)
+                        .with_files(Builder('file').titled(u'One'),
+                                    Builder('file').titled(u'Two')))
+        create(Builder('sl content page').titled(u'Sub Page 1').within(bl_page))
+        create(Builder('sl content page').titled(u'Sub Page 2').within(bl_page))
+
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+
+        self.assertEquals(['one', 'two'], bl_dow.objectIds())
+        self.assertEquals(['downloads', 'sub-page-1', 'sub-page-2'], bl_page.objectIds())
+
+        IStaging(wc_page).apply_working_copy()
+        self.assertEquals(['one', 'two'], bl_dow.objectIds())
+        self.assertEquals(['downloads', 'sub-page-1', 'sub-page-2'], bl_page.objectIds())
+
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+        wc_page.downloads.moveObjectsToTop('two')
+        IStaging(wc_page).apply_working_copy()
+        self.assertEquals(['two', 'one'], bl_dow.objectIds())
+
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+        create(Builder('file').titled(u'Three').within(wc_page.downloads))
+        wc_page.downloads.moveObjectsUp('three')
+        IStaging(wc_page).apply_working_copy()
+        self.assertEquals(['two', 'three', 'one'], bl_dow.objectIds())
+
     def test_sl_page_state_is_updated_when_applying_working_copy(self):
         with staticuid('baseline'):
             baseline = create(Builder('sl content page').titled(u'A page')


### PR DESCRIPTION
Preserve children's children order when applying working copies