### PR TITLE
Backport 2.x > 1.x - Fix EventBasic timezone conflict when applying working copies (#543)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.13 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Fix plone.app.events EventBasic timezone conflict when applying working copies [Nachtalb]
 
 
 1.23.12 (2019-08-27)

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -15,7 +15,6 @@ from ftw.simplelayout.staging.interfaces import IBaseline
 from ftw.simplelayout.staging.interfaces import IStaging
 from ftw.simplelayout.staging.interfaces import IWorkingCopy
 from ftw.simplelayout.utils import unrestricted_uuidToObject
-from ftw.simplelayout.utils import IS_PLONE_5
 from operator import methodcaller
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
@@ -40,15 +39,13 @@ from zope.lifecycleevent.interfaces import IObjectCopiedEvent
 from zope.schema import getFieldsInOrder
 import pkg_resources
 
-EVENT_SUPPORT = False
 try:
     pkg_resources.get_distribution('plone.app.event')
 except pkg_resources.DistributionNotFound:
-    pass
+    EVENT_SUPPORT = False
 else:
-    if not IS_PLONE_5:
-        EVENT_SUPPORT = True
-        from plone.app.event.dx.behaviors import EventBasic
+    EVENT_SUPPORT = True
+    from plone.app.event.dx.behaviors import EventBasic
 
 
 try:

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -5,6 +5,7 @@ from BTrees.OOBTree import OOBTree
 from contextlib import contextmanager
 from copy import deepcopy
 from DateTime import DateTime
+from datetime import datetime
 from ftw.simplelayout.configuration import columns_in_config
 from ftw.simplelayout.interfaces import IBlockConfiguration
 from ftw.simplelayout.interfaces import IPageConfiguration
@@ -14,6 +15,7 @@ from ftw.simplelayout.staging.interfaces import IBaseline
 from ftw.simplelayout.staging.interfaces import IStaging
 from ftw.simplelayout.staging.interfaces import IWorkingCopy
 from ftw.simplelayout.utils import unrestricted_uuidToObject
+from ftw.simplelayout.utils import IS_PLONE_5
 from operator import methodcaller
 from persistent.list import PersistentList
 from persistent.mapping import PersistentMapping
@@ -37,6 +39,16 @@ from zope.interface import noLongerProvides
 from zope.lifecycleevent.interfaces import IObjectCopiedEvent
 from zope.schema import getFieldsInOrder
 import pkg_resources
+
+EVENT_SUPPORT = False
+try:
+    pkg_resources.get_distribution('plone.app.event')
+except pkg_resources.DistributionNotFound:
+    pass
+else:
+    if not IS_PLONE_5:
+        EVENT_SUPPORT = True
+        from plone.app.event.dx.behaviors import EventBasic
 
 
 try:
@@ -380,8 +392,13 @@ class Staging(object):
             source_storage = schemata(source)
             target_storage = schemata(target)
             value = getattr(source_storage, name)
-            if isinstance(value, str):
+
+            if EVENT_SUPPORT and isinstance(target_storage, EventBasic) and \
+               isinstance(value, datetime):
+                value = getattr(source, name)
+            elif isinstance(value, str):
                 value = value.decode('utf-8')
+
             setattr(target_storage, field.getName(), value)
 
     def _copy_at_field_values(self, source, target):


### PR DESCRIPTION
Original #543