### PR TITLE
Fix support notice for plone 5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Installation
         ftw.simplelayout[contenttypes, mapblock]
 
 
-- With ftw.simplelayout 2.0.0 we introduced Plone support for this package. But Plone 4 has different dependencies. In order to use ftw.simpellayout 2.0.0 with Plone 4 also install the plone4 extra
+- With ftw.simplelayout 2.0.0 we introduced Plone 5 support for this package. But Plone 4 has different dependencies. In order to use ftw.simpellayout 2.0.0 with Plone 4 also install the plone4 extra
 
 ::
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Compatibility
    :target: https://jenkins.4teamwork.ch/job/ftw.simplelayout-master-test-plone-4.3.x.cfg
 
 
-Please use the `plone4` extra on Plone 4 Installations in order to have the right dependencies. 
+Please use the `plone4` extra on Plone 4 Installations in order to have the right dependencies.
 
 
 **Plone 5.1.x**

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Installation
         ftw.simplelayout[contenttypes, mapblock]
 
 
-- With ftw.simplelayout 2.0.0 we introduced Plone 5 support for this package. But Plone 4 has different dependencies. In order to use ftw.simpellayout 2.0.0 with Plone 4 also install the plone4 extra
+- With ftw.simplelayout 2.0.0 we introduced Plone 5 support for this package. But Plone 4 has different dependencies. In order to use ftw.simplelayout 2.0.0 with Plone 4 also install the plone4 extra
 
 ::
 


### PR DESCRIPTION
- "introduced Plone 5 support" instead of "introduced Plone support" (missing 5)
- simp**le**layout instead of simp**el**layout