### PR TITLE
Save file as blobs

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -8,6 +8,8 @@ Changelog
 - Fix galleryblock on click no big image available [Nachtalb]
 - Fix typo in settings description. [jone]
 - Install contenttypes extras by default and deprecate the extra itself [Nachtalb]
+- Save files uploaded via dropzone as blobs [Nachtalb]
+- Fix image rotation for images uploaded via dropzone [Nachtalb]
 
 
 2.1.2 (2019-08-29)

--- a/ftw/simplelayout/contenttypes/browser/dropzone.py
+++ b/ftw/simplelayout/contenttypes/browser/dropzone.py
@@ -5,8 +5,8 @@ from ftw.simplelayout.browser.ajax.utils import json_response
 from ftw.simplelayout.utils import IS_PLONE_5
 from plone import api
 from plone.dexterity.interfaces import IDexterityFTI
-from plone.namedfile.file import NamedFile
-from plone.namedfile.file import NamedImage
+from plone.namedfile.file import NamedBlobFile
+from plone.namedfile.file import NamedBlobImage
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
@@ -54,9 +54,9 @@ class DropzoneUploadBase(BrowserView):
 
         if self.is_dexterity_fti(portal_type):
             if file_field_name == 'image':
-                kwargs[file_field_name] = NamedImage(file_, filename=filename)    
+                kwargs[file_field_name] = NamedBlobImage(file_, filename=filename)
             else:
-                kwargs[file_field_name] = NamedFile(file_, filename=filename)
+                kwargs[file_field_name] = NamedBlobFile(file_, filename=filename)
             return api.content.create(**kwargs)
 
         else:


### PR DESCRIPTION
Files should be saved as blobs and not in the database as binary data.
This also fixes a bug that with images that are rotated via
exif:Orientation. When saving images as NamedImage the rotation fix by
plone.namedfile was not applied correctly, when using NamedBlobImage
though this works like a charm and fixes the images rotation.