### PR TITLE
Fix galleryblock on click no big image available

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 2.1.3 (unreleased)
 ------------------
 
+- Fix galleryblock on click no big image available [Nachtalb]
 - Fix typo in settings description. [jone]
 
 

--- a/ftw/simplelayout/contenttypes/hooks.py
+++ b/ftw/simplelayout/contenttypes/hooks.py
@@ -13,6 +13,7 @@ def clean_plone5_registry(site):
     allowed_sizes = registry['plone.allowed_sizes']
     # allowed_sizes.remove(u'colorbox 2000:2000')
     allowed_sizes.remove(u'simplelayout_galleryblock 480:480')
+    allowed_sizes.remove(u'sl_galleryblock_4k 3840:2160')
     allowed_sizes.remove(u'sl_textblock_small 480:480')
     allowed_sizes.remove(u'sl_textblock_middle 800:800')
     allowed_sizes.remove(u'sl_textblock_large 1280:1280')

--- a/ftw/simplelayout/contenttypes/profiles/default_plone5/registry.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default_plone5/registry.xml
@@ -4,6 +4,7 @@
            prefix="plone">
     <value key="allowed_sizes" purge="false">
       <element>simplelayout_galleryblock 480:480</element>
+      <element>sl_galleryblock_4k 3840:2160</element>
       <element>sl_textblock_small 480:480</element>
       <element>sl_textblock_middle 800:800</element>
       <element>sl_textblock_large 1280:1280</element>

--- a/ftw/simplelayout/contenttypes/upgrades/20191029182332_add_missing_image_scale/registry.xml
+++ b/ftw/simplelayout/contenttypes/upgrades/20191029182332_add_missing_image_scale/registry.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<registry>
+  <records interface="Products.CMFPlone.interfaces.controlpanel.IImagingSchema"
+           prefix="plone">
+    <value key="allowed_sizes" purge="false">
+      <element>sl_galleryblock_4k 3840:2160</element>
+    </value>
+  </records>
+</registry>

--- a/ftw/simplelayout/contenttypes/upgrades/20191029182332_add_missing_image_scale/upgrade.py
+++ b/ftw/simplelayout/contenttypes/upgrades/20191029182332_add_missing_image_scale/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class AddMissingImageScale(UpgradeStep):
+    """Add missing image scale.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
The image scale for the big image shown when clicking on a galleryblock
item was missing.