### PR TITLE
Fix save translation to match the rest of plone in plone 4 / 5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Add ftw.theming:default (upgrade step not provided). [busykoala]
+- Unify "Save" translation across content types and plone versions [Nachtalb]
 
 
 2.2.0 (2019-10-30)

--- a/ftw/simplelayout/browser/ajax/edit_block.py
+++ b/ftw/simplelayout/browser/ajax/edit_block.py
@@ -7,7 +7,7 @@ from plone.dexterity.browser.edit import DefaultEditForm
 from plone.dexterity.events import EditCancelledEvent
 from plone.dexterity.events import EditFinishedEvent
 from plone.dexterity.interfaces import IDexterityEditForm
-from Products.CMFPlone import PloneMessageFactory
+from plone.dexterity.i18n import MessageFactory as DXMF
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from z3c.form import button
@@ -36,7 +36,7 @@ class EditForm(DefaultEditForm):
 
     _finished_edit = False
 
-    @button.buttonAndHandler(PloneMessageFactory(u'Save'), name='save')
+    @button.buttonAndHandler(DXMF(u'Save'), name='save')
     def handleApply(self, action):
         data, errors = self.extractData()
         if errors:
@@ -53,7 +53,7 @@ class EditForm(DefaultEditForm):
 
         self._finished_edit = True
 
-    @button.buttonAndHandler(PloneMessageFactory(u'Cancel'), name='cancel')
+    @button.buttonAndHandler(DXMF(u'Cancel'), name='cancel')
     def handleCancel(self, action):
         notify(EditCancelledEvent(self.context))
 


### PR DESCRIPTION
In plone 4 the "Save" from `PloneMessageFactory` translates to "Sichern" whereas the rest of plone uses "Speichern" from `plone.dexterity.i18n`. So we use this as well to make sure the "Save" message is the same across the site and across plone versions.