### PR TITLE
Add ftw.theming:default profile.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ftw.theming:default (upgrade step not provided). [busykoala]
 
 
 2.2.0 (2019-10-30)

--- a/ftw/simplelayout/profiles/lib-plone5/metadata.xml
+++ b/ftw/simplelayout/profiles/lib-plone5/metadata.xml
@@ -2,5 +2,6 @@
 <metadata>
   <dependencies>
     <dependency>profile-collective.js.jqueryui:default</dependency>
+    <dependency>profile-ftw.theming:default</dependency>
   </dependencies>
 </metadata>

--- a/ftw/simplelayout/profiles/lib/metadata.xml
+++ b/ftw/simplelayout/profiles/lib/metadata.xml
@@ -2,5 +2,6 @@
 <metadata>
   <dependencies>
     <dependency>profile-collective.js.jqueryui:default</dependency>
+    <dependency>profile-ftw.theming:default</dependency>
   </dependencies>
 </metadata>


### PR DESCRIPTION
Essential features provided by ftw.simplelayout are not working without the profile ftw.theming:default. Therefore it makes sence to add it to the profiles installed on initialization. I do not add an upgrade step based on the assumption that existing installations using ftw.simplelayout solved the problem already.