### PR TITLE
Improve linking between baseline and working copy

### DIFF
--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-07-23 15:26+0000\n"
+"POT-Creation-Date: 2019-11-04 14:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -239,7 +239,7 @@ msgstr "Dieses behavior macht einen Inhalt geo-referenzierbar"
 msgid "This block is empty."
 msgstr "Dieser Block hat keinen Inhalt."
 
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:55
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:65
 msgid "This is no a valid youtube, or vimeo url."
 msgstr "Dies ist keine gültige Youtube- oder Vimeo-URL."
 
@@ -263,9 +263,9 @@ msgstr "Deinstalliert das ftw.simplelayout.mapblocks Paket"
 msgid "VideoBlock"
 msgstr "Video"
 
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:43
-msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
-msgstr "Youtube Format: http(s)://youtu.be/VIDEO_ID<br/>Youtube (no-cookie) Format: https://www.youtube-nocookie.com/embed/VIDEO_ID<br/>Vimeo Format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:50
+msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Youtube (no-cookie) format: https://www.youtube-nocookie.com/embed/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
+msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:6
@@ -649,7 +649,7 @@ msgid "label_upload"
 msgstr "Datei hochladen"
 
 #. Default: "Youtube, or Vimeo URL"
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:42
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:49
 msgid "label_video_url"
 msgstr "Video-URL"
 

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -678,10 +678,10 @@ msgstr "Breite: ${width}px (aktuell: ${current_width}px)"
 msgid "low_quality_image_label"
 msgstr "Bildauflösung ist nicht optimal"
 
-#. Default: "${owner} is working on this page in a ${link} copy created at ${date}."
-#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:15
+#. Default: "${owner} is working on this page in a ${link} created at ${date}."
+#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:17
 msgid "message_baseline"
-msgstr "${owner} überarbeitet diese Seite gerade in einer <a href='${link}'>Arbeitskopie</a>, erstellt am ${date}."
+msgstr "${owner} überarbeitet diese Seite gerade in einer ${link}, erstellt am ${date}."
 
 #. Default: "This is the working copy of this ${link}, created by ${owner} at ${date}."
 #: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:17
@@ -707,4 +707,9 @@ msgstr "Verwende das zugeschnittenes Bild ebenfalls für das Overlay"
 #: ./ftw/simplelayout/images/cropping/behaviors.py:18
 msgid "use_cropped_image_for_overlay_desc"
 msgstr "Wenn diese Option aktiviert ist, wird im Bild-Overlay das zugeschnittene Bild verwendet, sofern das Bild im Bildeditor zugeschnitten wurde. Deaktivieren Sie diese Option um das Originalbild im Bild-Overlay anzuzeigen."
+
+#. Default: "working copy"
+#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:15
+msgid "working_copy"
+msgstr "Arbeitskopie"
 

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -265,7 +265,7 @@ msgstr "Video"
 
 #: ./ftw/simplelayout/contenttypes/contents/videoblock.py:50
 msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Youtube (no-cookie) format: https://www.youtube-nocookie.com/embed/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
-msgstr ""
+msgstr "Youtube Format: http(s)://youtu.be/VIDEO_ID<br/>Youtube (kein Cookie) Format: https://www.youtube-nocookie.com/embed/VIDEO_ID<br/>Vimeo Format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
 #: ./ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt:6

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -287,6 +287,10 @@ msgstr "Möchten Sie diesen Eintrag wirklich löschen?"
 msgid "alert_really_delete_folder"
 msgstr "Möchten Sie diesen Ordner und seinen Inhalt wirklich löschen?"
 
+#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:13
+msgid "baseline"
+msgstr "Originalseite"
+
 #. Default: "creater"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:61
 msgid "column_creater"
@@ -679,10 +683,10 @@ msgstr "Bildauflösung ist nicht optimal"
 msgid "message_baseline"
 msgstr "${owner} überarbeitet diese Seite gerade in einer <a href='${link}'>Arbeitskopie</a>, erstellt am ${date}."
 
-#. Default: "This is the working copy of ${owner}, created at ${date}."
-#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:15
+#. Default: "This is the working copy of this ${link}, created by ${owner} at ${date}."
+#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:17
 msgid "message_working_copy"
-msgstr "Dies ist die Arbeitskopie von ${owner}, erstellt am ${date}."
+msgstr "Dies ist die Arbeitskopie von dieser ${link}, erstellt von ${owner} am ${date}."
 
 #. Default: "Optimal image quality: ${limit_str}"
 #: ./ftw/simplelayout/images/limits/validators.py:57

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -681,8 +681,8 @@ msgstr ""
 msgid "low_quality_image_label"
 msgstr ""
 
-#. Default: "${owner} is working on this page in a ${link} copy created at ${date}."
-#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:15
+#. Default: "${owner} is working on this page in a ${link} created at ${date}."
+#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:17
 msgid "message_baseline"
 msgstr ""
 
@@ -709,5 +709,10 @@ msgstr ""
 #. Default: "If you crop an image, the original image will be still available. Per default, the original image will be used for the overlay. If you want to show the cropped image instead, mark this option."
 #: ./ftw/simplelayout/images/cropping/behaviors.py:18
 msgid "use_cropped_image_for_overlay_desc"
+msgstr ""
+
+#. Default: "working copy"
+#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:15
+msgid "working_copy"
 msgstr ""
 

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-07-23 15:26+0000\n"
+"POT-Creation-Date: 2019-11-04 14:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -242,7 +242,7 @@ msgstr ""
 msgid "This block is empty."
 msgstr ""
 
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:55
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:65
 msgid "This is no a valid youtube, or vimeo url."
 msgstr ""
 
@@ -266,8 +266,8 @@ msgstr ""
 msgid "VideoBlock"
 msgstr ""
 
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:43
-msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:50
+msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Youtube (no-cookie) format: https://www.youtube-nocookie.com/embed/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -290,6 +290,10 @@ msgstr ""
 msgid "alert_really_delete_folder"
 msgstr ""
 
+#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:13
+msgid "baseline"
+msgstr ""
+
 #. Default: "creater"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:61
 msgid "column_creater"
@@ -682,8 +686,8 @@ msgstr ""
 msgid "message_baseline"
 msgstr ""
 
-#. Default: "This is the working copy of ${owner}, created at ${date}."
-#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:15
+#. Default: "This is the working copy of this ${link}, created by ${owner} at ${date}."
+#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:17
 msgid "message_working_copy"
 msgstr ""
 

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -681,8 +681,8 @@ msgstr ""
 msgid "low_quality_image_label"
 msgstr ""
 
-#. Default: "${owner} is working on this page in a ${link} copy created at ${date}."
-#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:15
+#. Default: "${owner} is working on this page in a ${link} created at ${date}."
+#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:17
 msgid "message_baseline"
 msgstr ""
 
@@ -709,5 +709,10 @@ msgstr ""
 #. Default: "If you crop an image, the original image will be still available. Per default, the original image will be used for the overlay. If you want to show the cropped image instead, mark this option."
 #: ./ftw/simplelayout/images/cropping/behaviors.py:18
 msgid "use_cropped_image_for_overlay_desc"
+msgstr ""
+
+#. Default: "working copy"
+#: ./ftw/simplelayout/staging/templates/baseline_viewlet.pt:15
+msgid "working_copy"
 msgstr ""
 

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2019-07-23 15:26+0000\n"
+"POT-Creation-Date: 2019-11-04 14:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -242,7 +242,7 @@ msgstr ""
 msgid "This block is empty."
 msgstr ""
 
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:55
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:65
 msgid "This is no a valid youtube, or vimeo url."
 msgstr ""
 
@@ -266,8 +266,8 @@ msgstr ""
 msgid "VideoBlock"
 msgstr ""
 
-#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:43
-msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
+#: ./ftw/simplelayout/contenttypes/contents/videoblock.py:50
+msgid "Youtube format: http(s)://youtu.be/VIDEO_ID<br/>Youtube (no-cookie) format: https://www.youtube-nocookie.com/embed/VIDEO_ID<br/>Vimeo format: http(s)://vimeo.com/(channels/groups)/VIDEO_ID"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -290,6 +290,10 @@ msgstr ""
 msgid "alert_really_delete_folder"
 msgstr ""
 
+#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:13
+msgid "baseline"
+msgstr ""
+
 #. Default: "creater"
 #: ./ftw/simplelayout/contenttypes/contents/filelistingblock.py:61
 msgid "column_creater"
@@ -682,8 +686,8 @@ msgstr ""
 msgid "message_baseline"
 msgstr ""
 
-#. Default: "This is the working copy of ${owner}, created at ${date}."
-#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:15
+#. Default: "This is the working copy of this ${link}, created by ${owner} at ${date}."
+#: ./ftw/simplelayout/staging/templates/workingcopy_viewlet.pt:17
 msgid "message_working_copy"
 msgstr ""
 

--- a/ftw/simplelayout/staging/templates/baseline_viewlet.pt
+++ b/ftw/simplelayout/staging/templates/baseline_viewlet.pt
@@ -11,7 +11,9 @@
       <dd i18n:translate="message_baseline">
         <tal:creator i18n:name="owner"
                      content="python:view.owner_name(working_copy)" />
-        is working on this page in a <tal:url i18n:name="link" content="working_copy/absolute_url" /> copy created at
+        is working on this page in a
+        <a i18n:name="link" tal:attributes="href working_copy/absolute_url" i18n:translate="working_copy">working copy</a>
+        created at
         <tal:date i18n:name="date" content="python:toLocalizedTime(working_copy.created())" />.
       </dd>
     </dl>

--- a/ftw/simplelayout/staging/templates/workingcopy_viewlet.pt
+++ b/ftw/simplelayout/staging/templates/workingcopy_viewlet.pt
@@ -9,9 +9,11 @@
     <dl class="portalMessage error">
       <dt i18n:translate="" i18n:domain="plone">Warning</dt>
       <dd i18n:translate="message_working_copy">
-        This is the working copy of
-        <tal:creator i18n:name="owner" content="view/owner_name" />,
-        created at
+        This is the working copy of this
+        <a i18n:name="link" tal:attributes="href view/baseline_url" i18n:translate="baseline">baseline</a>,
+        created by
+        <tal:creator i18n:name="owner" content="view/owner_name" />
+        at
         <tal:date i18n:name="date" content="python:toLocalizedTime(context.created())" />.
       </dd>
     </dl>

--- a/ftw/simplelayout/staging/viewlets.py
+++ b/ftw/simplelayout/staging/viewlets.py
@@ -15,6 +15,11 @@ class WorkingCopyViewlet(common.PathBarViewlet):
         owner = self.context.getOwner()
         return owner.getProperty('fullname') or owner.getId()
 
+    @property
+    def baseline_url(self):
+        baseline = IStaging(self.context).get_baseline()
+        return baseline.absolute_url()
+
 
 class BaselineViewlet(common.PathBarViewlet):
     index = ViewPageTemplateFile('templates/baseline_viewlet.pt')

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -352,7 +352,8 @@ class TestWorkingCopy(TestCase):
 
         browser.login().open(working_copy)
         statusmessages.assert_message(
-            'This is the working copy of test_user_1_, created at Jul 24, 2017.')
+            'This is the working copy of this baseline, created by '
+            'test_user_1_ at Jul 24, 2017.')
 
     @browsing
     def test_message_is_displayed_on_baseline(self, browser):
@@ -364,7 +365,8 @@ class TestWorkingCopy(TestCase):
 
         browser.login().open(baseline)
         statusmessages.assert_message(
-            'test_user_1_ is working on this page in a http://nohost/plone/copy_of_a-page copy created at Jul 24, 2017.')
+            'test_user_1_ is working on this page in a working copy created '
+            'at Jul 24, 2017.')
 
     @browsing
     def test_does_not_break_with_reference_to_sub_page(self, browser):


### PR DESCRIPTION
- Add a link from working copy to baseline
- Instead of showing the full URL of the working copy on the baseline, show an a tag with linking to the working copy

DE working copy ==> baseline
![image](https://user-images.githubusercontent.com/9467802/68132404-ee158400-ff1e-11e9-98ac-08a2e091622f.png)

EN baseline ==> working copy
![image](https://user-images.githubusercontent.com/9467802/68132495-19986e80-ff1f-11e9-86f1-f8040ea5259c.png)

