### PR TITLE
Leadimage: support changing the scale direction in the view call.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.23.15 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Leadimage: support changing the scale direction in the view call. [jone]
 
 
 1.23.14 (2019-11-11)

--- a/ftw/simplelayout/contenttypes/browser/leadimage.py
+++ b/ftw/simplelayout/contenttypes/browser/leadimage.py
@@ -15,9 +15,9 @@ class LeadImageView(BrowserView):
     _has_image = None
     block = None
 
-    def __call__(self, scale=None):
+    def __call__(self, scale=None, direction='down'):
         if self.has_image:
-            scale = self.get_scale(scale)
+            scale = self.get_scale(scale, direction=direction)
             return scale.tag()
         else:
             return ''
@@ -27,14 +27,14 @@ class LeadImageView(BrowserView):
         self._load()
         return self._has_image
 
-    def get_scale(self, scale=None):
+    def get_scale(self, scale=None, direction='down'):
         self._load()
         if not self.has_image:
             return
 
         scale = scale or self.request.get('scale', 'preview')
         scaler = self.block.restrictedTraverse('@@images')
-        return scaler.scale('image', scale=scale, direction="down")
+        return scaler.scale('image', scale=scale, direction=direction)
 
     def _get_uids(self):
         page_conf = IPageConfiguration(self.context)


### PR DESCRIPTION
This makes it possible for `ftw.events` and `ftw.news` to change the direction to "thumbnail" so that the image is scaled differently.

Backport of: https://github.com/4teamwork/ftw.simplelayout/pull/561