### PR TITLE
Add contenttypes to mapblock profile.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -9,6 +9,7 @@ Changelog
 
 - No longer accidentally load google maps api js twice. [mathias.leimgruber]
 
+- Add ftw.simplelayout.contenttypes profile when mapblock is added by default. [busykoala]
 
 
 2.4.1 (2019-11-14)

--- a/ftw/simplelayout/mapblock/profiles/default/metadata.xml
+++ b/ftw/simplelayout/mapblock/profiles/default/metadata.xml
@@ -2,5 +2,6 @@
 <metadata>
   <dependencies>
     <dependency>profile-collective.geo.bundle:default</dependency>
+    <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
   </dependencies>
 </metadata>

--- a/ftw/simplelayout/mapblock/profiles/default_plone5/metadata.xml
+++ b/ftw/simplelayout/mapblock/profiles/default_plone5/metadata.xml
@@ -2,5 +2,6 @@
 <metadata>
   <dependencies>
     <dependency>profile-collective.geo.bundle:default</dependency>
+    <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
   </dependencies>
 </metadata>

--- a/ftw/simplelayout/mapblock/profiles/uninstall/types/ftw.simplelayout.ContentPage.xml
+++ b/ftw/simplelayout/mapblock/profiles/uninstall/types/ftw.simplelayout.ContentPage.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<object name="ftw.simplelayout.ContentPage">
+
+    <property name="allowed_content_types" purge="False">
+        <element remove="true" value="ftw.simplelayout.MapBlock" />
+    </property>
+
+</object>


### PR DESCRIPTION
Mapblock is only used when contenttypes are installed also. Therefore it would be nice if there is a dependency so that when mapblock is getting installed also the contenttypes are getting installed.

This is particularly useful when we need to add mapblock as a dependency in another package where we otherwise had to put both instead of just one.

TODO:
- [x] Fix uninstall

```
AssertionError: u'Index: types/ftw.simplelayout.ContentPage.xml\n=============================== [truncated]... != ''
- Index: types/ftw.simplelayout.ContentPage.xml
- ===================================================================
- --- types/ftw.simplelayout.ContentPage.xml	2019/11/14 19:23:41.627561 GMT+1
- +++ types/ftw.simplelayout.ContentPage.xml	2019/11/14 19:23:41.627761 GMT+1
- @@ -19,6 +19,7 @@
-    <element value="ftw.simplelayout.ContentPage"/>
-    <element value="ftw.simplelayout.VideoBlock"/>
-    <element value="ftw.simplelayout.GalleryBlock"/>
- +  <element value="ftw.simplelayout.MapBlock"/>
-   </property>
-   <property name="allow_discussion">False</property>
-   <property name="default_view">@@simplelayout-view</property> : Quickinstaller seems not to uninstall everything.
```