### PR TITLE
Fix mapblock.js

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,8 @@ Changelog
 
 - Nothing changed yet.
 
+- No longer accidentally load google maps api js twice. [mathias.leimgruber]
+
 
 2.4.1 (2019-11-14)
 ------------------

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,9 +5,10 @@ Changelog
 2.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Change event binding on tab from onClick to just click in order to trigger the function on plone 5 too. [mathias.leimgruber]
 
 - No longer accidentally load google maps api js twice. [mathias.leimgruber]
+
 
 
 2.4.1 (2019-11-14)

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -107,7 +107,7 @@
           // Get hidden maps (maps with no size yet)
           if ($('.blockwidget-cgmap').filter(':hidden').length > 0) {
               var tabs = $('form.autotabs .autotoc-level-1, select.formTabs, ul.formTabs');
-              tabs.bind("onClick", function (e, index) {
+              tabs.bind("click", function (e, index) {
                 var curpanel = $(this).parents('form').find('.autotoc-section.active');
                 if (curpanel.length === 0)
                   curpanel = $(this).data('tabs').getCurrentPane();

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -108,7 +108,6 @@
           if ($('.blockwidget-cgmap').filter(':hidden').length > 0) {
               var tabs = $('form.autotabs .autotoc-level-1, select.formTabs, ul.formTabs');
               tabs.bind("onClick", function (e, index) {
-                initGoogleMaps();
                 var curpanel = $(this).parents('form').find('.autotoc-section.active');
                 if (curpanel.length === 0)
                   curpanel = $(this).data('tabs').getCurrentPane();


### PR DESCRIPTION
- Now runs with plone 5 - with click on tab
- No longer load google map api js twice - fixes issues in plone 4/5