### PR TITLE
Remove (AT) LinkBuilder in favour of the one in ftw.builder

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -11,6 +11,8 @@ Changelog
 
 - Add ftw.simplelayout.contenttypes profile when mapblock is added by default. [busykoala]
 
+- Remove (AT) LinkBuilder in favour of the one in ftw.builder. [djowett-ftw]
+
 
 2.4.1 (2019-11-14)
 ------------------

--- a/ftw/simplelayout/tests/builders.py
+++ b/ftw/simplelayout/tests/builders.py
@@ -1,6 +1,5 @@
 from ftw.builder import builder_registry
 from ftw.builder import create
-from ftw.builder.archetypes import ArchetypesBuilder
 from ftw.builder.dexterity import DexterityBuilder
 from ftw.simplelayout.configuration import synchronize_page_config_with_blocks
 from operator import methodcaller
@@ -80,9 +79,3 @@ class GalleryBlockBuilder(DexterityBuilder):
     portal_type = 'ftw.simplelayout.GalleryBlock'
 
 builder_registry.register('sl galleryblock', GalleryBlockBuilder)
-
-
-class LinkBuilder(ArchetypesBuilder):
-    portal_type = 'Link'
-
-builder_registry.register('link', LinkBuilder)


### PR DESCRIPTION
Use `ftw.builder >= 1.12.0` to replace this