### PR TITLE
Fix dependency issue with ftw.sliderblock

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Old versions of ftw.sliderblock depended on this product to require collective.upload, which
+is no longer done after version 2.0.  We raise ImportError on startup to make this clear. [djowett-ftw]
 
 
 2.5.1 (2019-11-29)

--- a/ftw/simplelayout/__init__.py
+++ b/ftw/simplelayout/__init__.py
@@ -1,7 +1,20 @@
+import pkg_resources
 from zope.i18nmessageid import MessageFactory
 
-
 _ = MessageFactory('ftw.simplelayout')
+
+
+try:
+    if pkg_resources.get_distribution('ftw.sliderblock').version < '2.0':
+        try:
+            pkg_resources.require('collective.quickupload')
+        except pkg_resources.DistributionNotFound:
+            msg = ("ftw.sliderblock < 2.0 requires collective.quickupload which is"
+                   " not installed. Either upgrade ftw.sliderblock >= 2.0 "
+                   "(recommended) or install collective.upload.")
+            raise ImportError(msg)
+except pkg_resources.DistributionNotFound:
+    pass
 
 
 def initialize(context):


### PR DESCRIPTION
    Old versions of ftw.sliderblock depended on this product to require collective.upload, which
    is no longer done after version 2.0

Resolves https://github.com/4teamwork/ftw.sliderblock/issues/45