### PR TITLE
Unpin six.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Old versions of ftw.sliderblock depended on this product to require collective.upload, which
 is no longer done after version 2.0.  We raise ImportError on startup to make this clear. [djowett-ftw]
+- Fix tests not opening files in binary mode (necessary to work with the latest release of ftw.testbrowser. [busykoala]
 
 
 2.5.1 (2019-11-29)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,7 +7,7 @@ Changelog
 
 - Old versions of ftw.sliderblock depended on this product to require collective.upload, which
 is no longer done after version 2.0.  We raise ImportError on startup to make this clear. [djowett-ftw]
-- Fix tests not opening files in binary mode (necessary to work with the latest release of ftw.testbrowser. [busykoala]
+- Fix tests not opening files in binary mode (necessary to work with the latest release of ftw.testbrowser). [busykoala]
 
 
 2.5.1 (2019-11-29)

--- a/ftw/simplelayout/tests/test_dropzone_upload.py
+++ b/ftw/simplelayout/tests/test_dropzone_upload.py
@@ -21,7 +21,7 @@ class TestDropZoneUpload(SimplelayoutTestCase):
         self.assertEquals([], listing.objectIds())
 
         browser.login()
-        self.make_dropzone_upload(listing, self.asset('world.txt').open('r'))
+        self.make_dropzone_upload(listing, self.asset('world.txt').open('rb'))
         self.assertEqual(201, browser.status_code)
         self.assertEqual({u'content': u'Created',
                           u'url': u'http://nohost/plone/page/downloads/world.txt',
@@ -54,7 +54,7 @@ class TestDropZoneUpload(SimplelayoutTestCase):
         self.assertEquals([], listing.objectIds())
 
         browser.login()
-        self.make_dropzone_upload(listing, self.asset('world.txt').open('r'))
+        self.make_dropzone_upload(listing, self.asset('world.txt').open('rb'))
         self.assertEqual(201, browser.status_code)
         self.assertEqual(
             {u'content': u'Created',
@@ -92,7 +92,7 @@ class TestDropZoneUpload(SimplelayoutTestCase):
         self.assertEquals([], gallery.objectIds())
 
         with browser.login().expect_http_error(400):
-            self.make_dropzone_upload(gallery, self.asset('world.txt').open('r'))
+            self.make_dropzone_upload(gallery, self.asset('world.txt').open('rb'))
 
         self.assertEqual({u'error': u'Only images can be added to the gallery.',
                           u'proceed': False}, browser.json)

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -7,7 +7,6 @@ package-name = ftw.simplelayout
 test-egg = ftw.simplelayout [tests, mapblock, plone4]
 
 [versions]
-six = 1.9.0
 collective.geo.behaviour = 1.2
 collective.geo.bundle = 2.3
 collective.geo.contentlocations = 3.1

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -7,7 +7,6 @@ package-name = ftw.simplelayout
 test-egg = ftw.simplelayout [tests, mapblock]
 
 [versions]
-six = 1.9.0
 ftw.upgrade = 2.9.0
 ftw.builder = 1.11.1
 ftw.theming = 2.0.0


### PR DESCRIPTION
Close https://github.com/4teamwork/ogb/issues/114

Pinning six does not seem to be necessary. Because it results in a version conflict I unpin it. The version conflict is a result of the release of ftw.testbrowser 2.0.0.

If files are not opened in binary mode testbrowser will fail here with the below error:
https://github.com/4teamwork/ftw.testbrowser/blob/2833d166e0a6b1f10c7d14da3f0560f4d15de868/ftw/testbrowser/form.py#L368
```
'unicode' does not have the buffer interface
```
Here first a broken example and then a working one:
```
file_ = open(Path('whatever.txt').abspath(), 'r')
browser.fill({u'File Fäldli': file_})
```
```
file_ = open(Path('whatever.txt').abspath(), 'rb')
browser.fill({u'File Fäldli': file_})
```