### PR TITLE
Fix history.txt.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,7 +6,7 @@ Changelog
 ------------------
 
 - Old versions of ftw.sliderblock depended on this product to require collective.upload, which
-is no longer done after version 2.0.  We raise ImportError on startup to make this clear. [djowett-ftw]
+  is no longer done after version 2.0.  We raise ImportError on startup to make this clear. [djowett-ftw]
 - Fix tests not opening files in binary mode (necessary to work with the latest release of ftw.testbrowser). [busykoala]
 - Remove unittest2 because of deprecation. [busykoala]
 


### PR DESCRIPTION
Fix: `(WARNING/2) Bullet list ends without a blank line; unexpected unindent.`