### PR TITLE
Fix loading error in filelistingblock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -28,6 +28,7 @@ Changelog
   is no longer done after version 2.0.  We raise ImportError on startup to make this clear. [djowett-ftw]
 - Fix tests not opening files in binary mode (necessary to work with the latest release of ftw.testbrowser). [busykoala]
 - Remove unittest2 because of deprecation. [busykoala]
+- Fix potential error after migrating to plone5 in filelisting-block. [busykoala]
 
 
 2.5.1 (2019-11-29)

--- a/ftw/simplelayout/contenttypes/browser/filelistingblock.py
+++ b/ftw/simplelayout/contenttypes/browser/filelistingblock.py
@@ -1,9 +1,10 @@
 from Acquisition._Acquisition import aq_inner
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ftw.simplelayout.browser.blocks.base import BaseBlock
 from ftw.simplelayout.contenttypes.contents import interfaces
 from ftw.table.interfaces import ITableGenerator
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone.dexterity.utils import safe_utf8
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
 
@@ -25,7 +26,7 @@ class FileListingBlockView(BaseBlock):
         path = '/'.join(self.context.getPhysicalPath())
         query['path'] = {'query': path, 'depth': 1}
         query['sort_on'] = self.context.sort_on
-        query['sort_order'] = self.context.sort_order
+        query['sort_order'] = safe_utf8(self.context.sort_order)
         return query
 
     def _get_columns(self, column_id):


### PR DESCRIPTION
Close https://github.com/4teamwork/izug.organisation/issues/1708

After a migration of the filelisting block, we had an issue with it to load. The sort_order is expected to be a utf-8 string but we passed in a Unicode string now. This resulted in a list of Falses for every char in the Unicode string instead of one False being returned in https://github.com/zopefoundation/Products.ZCatalog/blob/e751eff05374e7f8b39d59b9b9e16e33fab47e11/src/Products/ZCatalog/Catalog.py#L1085.