### PR TITLE
Move changelog to the top.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fix translation for 'Upload files here'. [djowett-ftw]
+- Fix potential error after migrating to plone5 in filelisting-block. [busykoala]
 
 
 2.5.4 (2019-12-18)
@@ -28,7 +29,6 @@ Changelog
   is no longer done after version 2.0.  We raise ImportError on startup to make this clear. [djowett-ftw]
 - Fix tests not opening files in binary mode (necessary to work with the latest release of ftw.testbrowser). [busykoala]
 - Remove unittest2 because of deprecation. [busykoala]
-- Fix potential error after migrating to plone5 in filelisting-block. [busykoala]
 
 
 2.5.1 (2019-11-29)


### PR DESCRIPTION
Because the rebase state wasn't up to date it placed the changelog at the wrong place.