### PR TITLE
Repair overlay styles

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.5.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Repair overlay styles. [djowett-ftw]
 
 
 2.5.5 (2019-12-20)

--- a/ftw/simplelayout/browser/ajax/templates/add.pt
+++ b/ftw/simplelayout/browser/ajax/templates/add.pt
@@ -1,5 +1,5 @@
 
-<div class="pb-ajax">
+<div class="sl-ajax">
   <h1 class="documentFirstHeading" tal:content="view/label">Title</h1>
   <div id="content-core" tal:content="structure view/contents" />
 </div>

--- a/ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt
+++ b/ftw/simplelayout/browser/ajax/templates/block_delete_confirmation.pt
@@ -1,5 +1,5 @@
 
-<div i18n:domain="ftw.simplelayout" class="delete pb-ajax"
+<div i18n:domain="ftw.simplelayout" class="delete sl-ajax"
      tal:define="folder_warning python:view.context_state.is_structural_folder();
                  number_of_objects_to_delete python:folder_warning and len(view.block.portal_catalog.searchResults(dict(path='/'.join(view.block.getPhysicalPath()), portal_type=view.context.plone_utils.getUserFriendlyTypes())));
                  item_locked view/is_locked_for_current_user | nothing">

--- a/ftw/simplelayout/browser/ajax/templates/edit_block_form.pt
+++ b/ftw/simplelayout/browser/ajax/templates/edit_block_form.pt
@@ -1,4 +1,4 @@
-<div class="pb-ajax">
+<div class="sl-ajax">
   <h1 class="documentFirstHeading" tal:content="view/label | nothing" />
   <div id="content-core">
       <metal:block use-macro="context/@@ploneform-macros/titlelessform" />

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -657,6 +657,13 @@ ul[class^="sl-toolbar"] {
   }
 }
 
+.sl-ajax {
+  overflow-y: auto;
+  width: 100%;
+  height: 100%;
+  padding-right: 1em;
+}
+
 .overlay-open body {
   overflow: hidden;
   .imageCropperWrapper {

--- a/ftw/simplelayout/mapblock/browser/resources/mapblock.js
+++ b/ftw/simplelayout/mapblock/browser/resources/mapblock.js
@@ -92,7 +92,7 @@
       });
 
       // Fix mouse pointer position according to openlayers pointer
-      $(mapWidgets.closest(".pb-ajax")).on("scroll", function(){
+      $(mapWidgets.closest(".sl-ajax")).on("scroll", function(){
         mapWidgets.collectivegeo("refresh");
       });
     }


### PR DESCRIPTION
Resolves https://github.com/4teamwork/izug.organisation/issues/1720

Looking somewhat better 

<img width="910" alt="Screenshot 2020-01-06 at 15 50 27" src="https://user-images.githubusercontent.com/54800639/71826290-de8cf580-309d-11ea-8824-0cb9d2dd91b3.png">


<img width="638" alt="Screenshot 2020-01-06 at 15 52 24" src="https://user-images.githubusercontent.com/54800639/71826308-e51b6d00-309d-11ea-9483-602b060bc408.png">

<img width="903" alt="Screenshot 2020-01-06 at 15 57 47" src="https://user-images.githubusercontent.com/54800639/71826316-e9478a80-309d-11ea-9485-9799773b1ada.png">

<img width="1436" alt="Screenshot 2020-01-06 at 15 52 03" src="https://user-images.githubusercontent.com/54800639/71826328-f1072f00-309d-11ea-8d61-c26bb170b818.png">


referencewidget could be clearer on styling expandable (traversable) items, but I guess that's a different issue
