### PR TITLE
Remove link builder in 1.x branch

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.24.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove (AT) LinkBuilder in favour of the one in ftw.builder. (backport)
+  [djowett-ftw]
 
 
 1.24.0 (2019-11-14)

--- a/ftw/simplelayout/tests/builders.py
+++ b/ftw/simplelayout/tests/builders.py
@@ -1,6 +1,5 @@
 from ftw.builder import builder_registry
 from ftw.builder import create
-from ftw.builder.archetypes import ArchetypesBuilder
 from ftw.builder.dexterity import DexterityBuilder
 from ftw.simplelayout.configuration import synchronize_page_config_with_blocks
 from operator import methodcaller
@@ -80,9 +79,3 @@ class GalleryBlockBuilder(DexterityBuilder):
     portal_type = 'ftw.simplelayout.GalleryBlock'
 
 builder_registry.register('sl galleryblock', GalleryBlockBuilder)
-
-
-class LinkBuilder(ArchetypesBuilder):
-    portal_type = 'Link'
-
-builder_registry.register('link', LinkBuilder)

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -7,6 +7,6 @@ package-name = ftw.simplelayout
 test-egg = ftw.simplelayout [tests, contenttypes, mapblock]
 
 [versions]
-six = 1.9.0
+six = 1.12.0
 collective.geo.openlayers = <4a
 collective.geo.mapwidget = <3a


### PR DESCRIPTION
This is otherwise incompatible with ftw.builder > 1.12