### PR TITLE
Make migration more robust.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.5.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make migration more robust. [mbaechtold]
 
 
 2.5.9 (2020-01-21)

--- a/ftw/simplelayout/migration.py
+++ b/ftw/simplelayout/migration.py
@@ -268,7 +268,9 @@ def migrate_image_to_file(obj):
     MigrateToFile(obj.portal_setup)
 
     # clear archetypes.schemaextender cache
-    getattr(obj.REQUEST, CACHE_KEY).pop(IUUID(obj), None)
+    archetypes_schemaextender_cache = getattr(obj.REQUEST, CACHE_KEY)
+    if archetypes_schemaextender_cache:
+        archetypes_schemaextender_cache.pop(IUUID(obj), None)
 
     ifaces_to_remove = (set(providedBy(obj)) -
                         set(implementedBy(obj.__class__)))


### PR DESCRIPTION
In order to disable the archetypes archetypes schemaextender cache we simply set it to `False`. Our code would then fail. Let's improve that.