### PR TITLE
Fix youtube integration. The iframe is now stored in `f` not `a`.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.25.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Backport of from 2.x e1392375e96cf3f6575c59555fe16ae9ce6bc522
+  Fix youtube player integration [mathias.leimgruber]
 
 
 1.25 (2020-02-05)

--- a/ftw/simplelayout/browser/resources/videoblock.js
+++ b/ftw/simplelayout/browser/resources/videoblock.js
@@ -12,7 +12,7 @@
   function resizeAll() { $.map($(".sl-youtube-video"), resizeYoutubePlayer); }
 
   function onPlayerReady(player) {
-    var iframe = player.target.a;
+    var iframe = player.target.f;
 
     ratios[iframe.id] = ratios[iframe.id] || iframe.height/iframe.width;
 


### PR DESCRIPTION
This is a backport of e1392375e96cf3f6575c59555fe16ae9ce6bc522