### PR TITLE
Fix deletion of blocks within non-simplelayoutish containers

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.5.11 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix deletion of blocks if parent is not simplelayoutish. [mbaechtold]
 
 
 2.5.10 (2020-03-24)

--- a/ftw/simplelayout/handlers.py
+++ b/ftw/simplelayout/handlers.py
@@ -73,7 +73,11 @@ def update_page_state_on_block_remove(block, event):
         if parent is not event.oldParent:
             return
 
-        config = IPageConfiguration(parent)
+        config = IPageConfiguration(parent, None)
+        if not config:
+            # We are not able to update the page state if the parent
+            # of the block is not simplelayoutish at all.
+            return
         page_state = config.load()
 
         for container in page_state.values():

--- a/ftw/simplelayout/tests/test_delete_block.py
+++ b/ftw/simplelayout/tests/test_delete_block.py
@@ -1,5 +1,6 @@
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_FUNCTIONAL_TESTING
 from ftw.simplelayout.testing import SimplelayoutTestCase
 from ftw.testbrowser import browsing
@@ -36,3 +37,40 @@ class TestBlockDelete(SimplelayoutTestCase):
         browser.find('Delete').click()
 
         self.assertEquals(0, len(self.contentpage.objectValues()))
+
+
+class TestRemoveBlockWithinNonSimplelayoutContainer(SimplelayoutTestCase):
+
+    layer = FTW_SIMPLELAYOUT_CONTENT_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.setup_sample_ftis(self.portal)
+        self.setup_block_views()
+
+    @browsing
+    def test_block_deletion_within_non_simplelayout_container(self, browser):
+        """
+        This tests ensures that simplelayout blocks can be deleted if they
+        are container within a non-simplelayout container.
+        """
+        # Create a non-simplelayoutish container (this is the case with
+        # a `ftw.book.Book` where we first spotted the issue).
+        container = create(Builder('folder'))
+
+        # Create a simplelayout block within a non-simplelayoutish
+        # container (this is the case with `ftw.book.Chapter` created
+        # within a `ftw.book Book` where we first spotted the issue).
+        block = create(Builder('sample block').titled('the block').within(container))
+        self.assertEqual(['the-block'], container.objectIds())
+
+        # Now delete the block. This triggers
+        # `ftw.simplelayout.handlers.update_page_state_on_block_remove` which
+        # used to fail if the container was non-simplelayoutish.
+        browser.login().visit(container, view='folder_contents')
+        browser.visit(block, view='delete_confirmation')
+        browser.find_button_by_label('Delete').click()
+
+        # Make sure the block has gone. This is not the real goal of this
+        # test. But if we get here, the deletion of the block was successful.
+        self.assertEqual([], container.objectIds())


### PR DESCRIPTION
Deleting a simplelayout block created within a non-simplelayoutish container used to raise the following error in `ftw.simplelayout.handlers.update_page_state_on_block_remove`:

> TypeError: ('Could not adapt', <SampleNonSimplelayoutContainer at /plone/samplenonsimplelayoutcontainer>, <InterfaceClass ftw.simplelayout.interfaces.IPageConfiguration>)

This was first spotted with `ftw.book.Chapter` (block) and `ftw.book.Book` (container).