### PR TITLE
Add vimeo video iframe wrapper.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.5.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add vimeo video iframe wrapper for better styling possibility. [busykoala]
 
 
 2.5.13 (2020-04-24)

--- a/ftw/simplelayout/contenttypes/browser/templates/videoblock_vimeo.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/videoblock_vimeo.pt
@@ -1,2 +1,4 @@
 <h2 tal:content="view/block_title" tal:condition="view/block_title">Title</h2>
-<iframe tal:attributes="src view/vimeo_player" width="100%" height="500px" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+<div class="iframe-video-wrapper">
+  <iframe tal:attributes="src view/vimeo_player" width="100%" height="500px" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+</div>


### PR DESCRIPTION
This helps styling the iframe sizing with e.g. styles like:
```
.iframe-video-wrapper {
overflow: hidden;
  // Calculated from the aspect ration of the content (in case of 16:9 it is 9/16= 0.5625)
  padding-top: 56.25%;
  position: relative;
}

.iframe-video-wrapper iframe {
  border: 0;
  height: 100%;
  left: 0;
  position: absolute;
  top: 0;
  width: 100%;
}
```