### PR TITLE
Aliasblock adjustments

### DIFF
--- a/ftw/simplelayout/aliasblock/contents/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/contents/aliasblock.py
@@ -12,10 +12,6 @@ from zope.interface import alsoProvides
 from zope.interface import implements
 
 
-def get_alias_path(widget):
-    return '/'.join(api.portal.get().getPhysicalPath())
-
-
 def get_selectable_blocks():
     return ['ftw.simplelayout.TextBlock',
             'ftw.simplelayout.GalleryBlock',
@@ -43,7 +39,6 @@ class IAliasBlockSchema(form.Schema):
             default=u'Choose a block to be rendered within this block.'),
         required=True,
         source=ReferenceObjSourceBinder(
-            root_path=get_alias_path,
             selectable=get_selectable_blocks(),
             override=True
         )

--- a/ftw/simplelayout/aliasblock/contents/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/contents/aliasblock.py
@@ -29,7 +29,7 @@ class IAliasBlockSchema(form.Schema):
     """
 
     widget('alias', ReferenceBrowserWidget,
-           start=get_alias_path,
+           start='parent',
            )
     alias = RelationChoice(
         title=_(u'label_alias_content',


### PR DESCRIPTION
"Parent" as start value results in having the reference browser opening in the current section of the tree. 
<img width="895" alt="Screen Shot 2020-06-01 at 10 57 18" src="https://user-images.githubusercontent.com/437933/83393359-f2434a80-a3f6-11ea-8232-2eed163ea56d.png">

- There is no need to set `root_path` if it's the plone root anyway. 
