### PR TITLE
Fix path issue on startpages (non sl pages using sl appearance).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix image resize issue on non simplelayout page using the simplelayout design. [busykoala]
 
 
 2.6.1 (2020-06-02)

--- a/ftw/simplelayout/contenttypes/contents/textblock.py
+++ b/ftw/simplelayout/contenttypes/contents/textblock.py
@@ -16,6 +16,7 @@ from zope import schema
 from zope.i18n import translate
 from zope.interface import alsoProvides
 from zope.interface import implements
+import os
 
 
 class ITextBlockSchema(form.Schema):
@@ -118,13 +119,15 @@ class TextBlockModifier(object):
 class TextBlockActions(DefaultActions):
 
     def specific_actions(self):
+        base_path = '/'.join(self.context.getPhysicalPath())
+
         return OrderedDict([
             ('imageLeft', {
                 'class': 'sl-icon-image-left block-server-action',
                 'title': translate(
                     _(u'label_float_image_left', default=u'Float image left'),
                     context=self.request),
-                'href': './sl-ajax-reload-block-view',
+                'href': os.path.join(base_path, 'sl-ajax-reload-block-view'),
                 'data-scale': 'sl_textblock_small',
                 'data-imagefloat': 'left'
             }),
@@ -134,7 +137,7 @@ class TextBlockActions(DefaultActions):
                     _(u'label_float_large_image_left',
                       default=u'Float large image left'),
                     context=self.request),
-                'href': './sl-ajax-reload-block-view',
+                'href': os.path.join(base_path, 'sl-ajax-reload-block-view'),
                 'data-scale': 'sl_textblock_middle',
                 'data-imagefloat': 'left'
             }),
@@ -144,7 +147,7 @@ class TextBlockActions(DefaultActions):
                     _(u'label_image_without_floating',
                       default=u'Image without floating'),
                     context=self.request),
-                'href': './sl-ajax-reload-block-view',
+                'href': os.path.join(base_path, 'sl-ajax-reload-block-view'),
                 'data-scale': 'sl_textblock_large',
                 'data-imagefloat': 'no-float'
             }),
@@ -154,7 +157,7 @@ class TextBlockActions(DefaultActions):
                     _(u'label_float_large_image_right',
                       default=u'Float large image right'),
                     context=self.request),
-                'href': './sl-ajax-reload-block-view',
+                'href': os.path.join(base_path, 'sl-ajax-reload-block-view'),
                 'data-scale': 'sl_textblock_middle',
                 'data-imagefloat': 'right'
             }),
@@ -164,7 +167,7 @@ class TextBlockActions(DefaultActions):
                     _(u'label_float_image_right',
                       default=u'Float image right'),
                     context=self.request),
-                'href': './sl-ajax-reload-block-view',
+                'href': os.path.join(base_path, 'sl-ajax-reload-block-view'),
                 'data-scale': 'sl_textblock_small',
                 'data-imagefloat': 'right'
             }),
@@ -173,6 +176,6 @@ class TextBlockActions(DefaultActions):
                 'title': translate(
                     _(u'label_crop_image', default='Crop image'),
                     context=self.request),
-                'href': './sl-ajax-crop-image'
+                'href': os.path.join(base_path, 'sl-ajax-crop-image')
             }),
         ])


### PR DESCRIPTION
The problem was that when non sl page were using the sl appearance the context on e.g. a startpage (plone site) would be the application instead of the platform. This resulted in an issue because the block object could not be found because no site is set on this context.

Adding the whole path instead of the relative part resolves this issue and the image size can be switched now.