### PR TITLE
Do not allow to add a reference to a contentpage which contains a aliasblock

### DIFF
--- a/ftw/simplelayout/aliasblock/contents/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/contents/aliasblock.py
@@ -17,8 +17,15 @@ class AliasBlockSelectable(DefaultSelectable):
 
     def is_selectable(self):
         selectable = super(AliasBlockSelectable, self).is_selectable()
-        return selectable
+        is_sl_page = self.content.portal_type == 'ftw.simplelayout.ContentPage'
 
+        # Don't allow sl pages containing another AliasBlock
+        if is_sl_page:
+            return not bool(filter(
+                lambda item: item.portal_type == 'ftw.simplelayout.AliasBlock',
+                self.content.objectValues()
+            ))
+        return selectable
 
 
 def get_selectable_blocks():

--- a/ftw/simplelayout/aliasblock/contents/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/contents/aliasblock.py
@@ -8,9 +8,11 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.directives import form
 from plone.directives.form import widget
+from z3c.form import validator
 from z3c.relationfield.schema import RelationChoice
 from zope.interface import alsoProvides
 from zope.interface import implements
+from zope.interface import Invalid
 
 
 class AliasBlockSelectable(DefaultSelectable):
@@ -61,6 +63,27 @@ class IAliasBlockSchema(form.Schema):
         )
     )
 
+
+class ContentPageValidator(validator.SimpleFieldValidator):
+    """Don't allow sl pages containing another AliasBlock"""
+
+    def validate(self, value):
+        """Validate international phone number on input"""
+        if not AliasBlockSelectable(self.field.source, value)():
+            if value.portal_type == 'ftw.simplelayout.ContentPage':
+                raise Invalid(
+                    _(u'eror_text_sl_page_aliasblock',
+                      default=u'The selected ContentPage contains a Aliasblock and cannot be selected'))
+            else:
+                raise Invalid(
+                    _(u'eror_text_alias_aliasblock',
+                      default=u'The selected Content cannot be selected'))
+
+
+validator.WidgetValidatorDiscriminators(
+    ContentPageValidator,
+    field=IAliasBlockSchema['alias']
+)
 
 alsoProvides(IAliasBlockSchema, IFormFieldProvider)
 

--- a/ftw/simplelayout/aliasblock/contents/configure.zcml
+++ b/ftw/simplelayout/aliasblock/contents/configure.zcml
@@ -2,4 +2,6 @@
     xmlns="http://namespaces.zope.org/zope"
     i18n_domain="ftw.simplelayout">
 
+    <adapter factory=".aliasblock.ContentPageValidator" />
+
 </configure>

--- a/ftw/simplelayout/tests/test_alias_block.py
+++ b/ftw/simplelayout/tests/test_alias_block.py
@@ -19,16 +19,17 @@ class TestAliasBlockRendering(TestCase):
     def setUp(self):
         self.page1 = create(Builder('sl content page'))
         self.page2 = create(Builder('sl content page'))
+        self.textblock = create(Builder('sl textblock')
+                                .titled(u'\xc4s Bl\xf6ckli')
+                                .within(self.page1))
+
         self.intids = getUtility(IIntIds)
 
     @browsing
     def test_create_aliasblock(self, browser):
-        textblock = create(Builder('sl textblock')
-                           .titled(u'\xc4s Bl\xf6ckli')
-                           .within(self.page1))
         alias = create(Builder('sl aliasblock')
                        .having(alias=RelationValue(
-                           self.intids.getId(textblock)))
+                           self.intids.getId(self.textblock)))
                        .within(self.page2))
 
         browser.visit(self.page2)
@@ -38,26 +39,20 @@ class TestAliasBlockRendering(TestCase):
 
     @browsing
     def test_add_aliasblock_using_factoriesmenu(self, browser):
-        textblock = create(Builder('sl textblock')
-                           .titled(u'\xc4s Bl\xf6ckli')
-                           .within(self.page1))
         browser.login().visit(self.page2)
         factoriesmenu.add('AliasBlock')
 
         form = browser.find_form_by_field('Alias Content')
-        form.find_widget('Alias Content').fill(textblock)
+        form.find_widget('Alias Content').fill(self.textblock)
         browser.find_button_by_label('Save').click()
 
         self.assertTrue(browser.css('.sl-alias-block'))
 
     @browsing
     def test_render_textblock_in_aliasblock(self, browser):
-        textblock = create(Builder('sl textblock')
-                           .titled(u'\xc4s Bl\xf6ckli')
-                           .within(self.page1))
         create(Builder('sl aliasblock')
                .having(alias=RelationValue(
-                       self.intids.getId(textblock)))
+                       self.intids.getId(self.textblock)))
                .within(self.page2))
 
         browser.visit(self.page2)
@@ -69,15 +64,12 @@ class TestAliasBlockRendering(TestCase):
 
     @browsing
     def test_has_message_if_referenced_block_was_deleted(self, browser):
-        textblock = create(Builder('sl textblock')
-                           .titled(u'\xc4s Bl\xf6ckli')
-                           .within(self.page1))
         create(Builder('sl aliasblock')
                .having(alias=RelationValue(
-                       self.intids.getId(textblock)))
+                       self.intids.getId(self.textblock)))
                .within(self.page2))
 
-        api.content.delete(obj=textblock, check_linkintegrity=False)
+        api.content.delete(obj=self.textblock, check_linkintegrity=False)
         transaction.commit()
         browser.visit(self.page2)
         block_content = browser.css('.sl-alias-block').first.text

--- a/ftw/simplelayout/tests/test_alias_block.py
+++ b/ftw/simplelayout/tests/test_alias_block.py
@@ -92,3 +92,23 @@ class TestAliasBlockRendering(TestCase):
                           statusmessages.error_messages())
         self.assertEquals('Constraint not satisfied',
                           browser.css('#formfield-form-widgets-alias .error').first.text)
+
+    @browsing
+    def test_dont_allow_pages_with_alias_block(self, browser):
+        browser.login().visit(self.page1)
+        alias = create(Builder('sl aliasblock')
+                       .having(alias=RelationValue(
+                           self.intids.getId(self.textblock)))
+                       .within(self.page2))
+
+        browser.login().visit(self.page1)
+        factoriesmenu.add('AliasBlock')
+
+        form = browser.find_form_by_field('Alias Content')
+        form.find_widget('Alias Content').fill(self.page2)
+
+        browser.find_button_by_label('Save').click()
+        self.assertEquals(['There were some errors.'],
+                          statusmessages.error_messages())
+        self.assertEquals('Constraint not satisfied',
+                          browser.css('#formfield-form-widgets-alias .error').first.text)

--- a/ftw/simplelayout/tests/test_alias_block.py
+++ b/ftw/simplelayout/tests/test_alias_block.py
@@ -90,7 +90,7 @@ class TestAliasBlockRendering(TestCase):
         browser.find_button_by_label('Save').click()
         self.assertEquals(['There were some errors.'],
                           statusmessages.error_messages())
-        self.assertEquals('Constraint not satisfied',
+        self.assertEquals('The selected Content cannot be selected',
                           browser.css('#formfield-form-widgets-alias .error').first.text)
 
     @browsing
@@ -110,5 +110,5 @@ class TestAliasBlockRendering(TestCase):
         browser.find_button_by_label('Save').click()
         self.assertEquals(['There were some errors.'],
                           statusmessages.error_messages())
-        self.assertEquals('Constraint not satisfied',
+        self.assertEquals('The selected ContentPage contains a Aliasblock and cannot be selected',
                           browser.css('#formfield-form-widgets-alias .error').first.text)


### PR DESCRIPTION
This prevents possible recursions and weird behavior for the editor.

I also adde more understandable error messages then just "Constraint not satisfied".