### PR TITLE
Implement rendering of sl page in a alias block.

### DIFF
--- a/ftw/simplelayout/aliasblock/browser/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/browser/aliasblock.py
@@ -1,6 +1,9 @@
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from ftw.simplelayout.browser.blocks.base import BaseBlock
+from ftw.simplelayout.browser.provider import SimplelayoutRenderer
+from ftw.simplelayout.interfaces import IPageConfiguration
+from ftw.simplelayout.interfaces import ISimplelayout
 from ftw.simplelayout.utils import get_block_html
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
 class AliasBlockView(BaseBlock):
@@ -9,8 +12,22 @@ class AliasBlockView(BaseBlock):
 
     def __init__(self, context, request):
         super(AliasBlockView, self).__init__(context, request)
-        self.referenced_page = self.context.alias.to_object
+        self.referenced_obj = self.context.alias.to_object
 
     def get_referenced_block_content(self):
-        """Returns the rendered simplayout block"""
-        return get_block_html(self.referenced_page)
+        """Returns the rendered simplayout content"""
+        if ISimplelayout.providedBy(self.referenced_obj):
+            return self.get_referenced_page_content()
+        else:
+            return get_block_html(self.referenced_obj)
+
+    def get_referenced_page_content(self):
+        page_conf = IPageConfiguration(self.referenced_obj)
+        storage = page_conf.load()
+        view = self.referenced_obj.restrictedTraverse('view')
+        sl_renderer = SimplelayoutRenderer(self.referenced_obj,
+                                           storage,
+                                           'default',
+                                           view=view)
+        return sl_renderer.render_layout()
+

--- a/ftw/simplelayout/aliasblock/contents/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/contents/aliasblock.py
@@ -39,7 +39,8 @@ def get_selectable_blocks():
             'ftw.events.EventListingBlock',
             'ftw.iframeblock.IFrameBlock',
             'ftw.addressblock.AddressBlock',
-            'ftw.simplelayout.MapBlock']
+            'ftw.simplelayout.MapBlock',
+            'ftw.simplelayout.ContentPage']
 
 
 class IAliasBlockSchema(form.Schema):

--- a/ftw/simplelayout/tests/test_alias_block.py
+++ b/ftw/simplelayout/tests/test_alias_block.py
@@ -11,6 +11,7 @@ from unittest import TestCase
 from z3c.relationfield import RelationValue
 from zope.component import getUtility
 from zope.intid.interfaces import IIntIds
+import difflib
 import transaction
 
 
@@ -26,6 +27,17 @@ class TestAliasBlockRendering(TestCase):
                                 .within(self.page1))
 
         self.intids = getUtility(IIntIds)
+
+    def assert_html(self, page_html, aliasblock_html):
+        diff = difflib.unified_diff(
+            page_html.strip().split('\n'),
+            aliasblock_html.strip().split('\n'),
+            fromfile='page',
+            tofile='aliasblock'
+        )
+        output = list(diff)
+        if len(output) != 0:            
+            self.fail('HTML differs:\n{}'.format('\n'.join(output)))
 
     @browsing
     def test_create_aliasblock(self, browser):
@@ -148,4 +160,5 @@ class TestAliasBlockRendering(TestCase):
             browser.css('.sl-alias-block .sl-layout').first.node,
             pretty_print=True
         )
-        self.assertEquals(html_page1_layout1, html_aliasblock_layout1)
+        self.assert_html(html_page1_layout1, html_aliasblock_layout1)
+


### PR DESCRIPTION
Looks not too bad otherwise 😊 

<img width="946" alt="Screen Shot 2020-06-04 at 17 03 20" src="https://user-images.githubusercontent.com/437933/83777704-0357ba00-a68a-11ea-95b0-020678414eb3.png">


<img width="921" alt="Screen Shot 2020-06-04 at 17 03 30" src="https://user-images.githubusercontent.com/437933/83777676-fc30ac00-a689-11ea-867b-b401d72d67ff.png">


- I added a `assert_html` helper in order to have a `udiff` output if it differs.