### PR TITLE
Show a nicer message if the content is not accessable.

### DIFF
--- a/ftw/simplelayout/aliasblock/browser/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/browser/aliasblock.py
@@ -3,6 +3,7 @@ from ftw.simplelayout.browser.provider import SimplelayoutRenderer
 from ftw.simplelayout.interfaces import IPageConfiguration
 from ftw.simplelayout.interfaces import ISimplelayout
 from ftw.simplelayout.utils import get_block_html
+from plone import api
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
 
@@ -13,6 +14,9 @@ class AliasBlockView(BaseBlock):
     def __init__(self, context, request):
         super(AliasBlockView, self).__init__(context, request)
         self.referenced_obj = self.context.alias.to_object
+
+    def has_view_permission(self):
+        return api.user.has_permission('View', obj=self.referenced_obj)
 
     def get_referenced_block_content(self):
         """Returns the rendered simplayout content"""
@@ -30,4 +34,3 @@ class AliasBlockView(BaseBlock):
                                            'default',
                                            view=view)
         return sl_renderer.render_layout()
-

--- a/ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt
+++ b/ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt
@@ -5,7 +5,7 @@
 <div class="sl-alias-block">
 
   <tal:ref-valid condition="not: context/alias/isBroken">
-    <tal:authorized condition="view/get_referenced_block_content">
+    <tal:authorized condition="view/has_view_permission">
       <a tal:attributes="href context/alias/to_path"
          class="sl-alias-block-visit-block"
          i18n:translate="label_visit_block">
@@ -14,6 +14,10 @@
       <tal:alias-block content="structure view/get_referenced_block_content" />
     </tal:authorized>
   </tal:ref-valid>
+
+  <tal:not-authorized condition="not: view/has_view_permission">
+    <p i18n:translate="label_invalid_permission">The content is no longer accessible to you</p>
+  </tal:not-authorized>
 
   <tal:ref-invalid condition="context/alias/isBroken">
     <p i18n:translate="label_invalid_reference">The embedded block does not exist.</p>

--- a/ftw/simplelayout/tests/test_alias_block.py
+++ b/ftw/simplelayout/tests/test_alias_block.py
@@ -162,3 +162,16 @@ class TestAliasBlockRendering(TestCase):
         )
         self.assert_html(html_page1_layout1, html_aliasblock_layout1)
 
+    @browsing
+    def test_respect_view_permission(self, browser):
+        alias = create(Builder('sl aliasblock')
+                       .having(alias=RelationValue(
+                           self.intids.getId(self.textblock)))
+                       .within(self.page2))
+
+        self.page1.manage_permission('View', roles=[])
+        self.page1.reindexObjectSecurity()
+        transaction.commit()
+        browser.login().visit(self.page2)
+        self.assertEquals('The content is no longer accessible to you',
+                          browser.css('.sl-alias-block p').first.text)


### PR DESCRIPTION
Otherwise the "The block could not be rendered" shows to a author. 