### PR TITLE
Add google map js to aliasblock add/edit form. In case the block returns map content this is necessary.

### DIFF
--- a/ftw/simplelayout/aliasblock/browser/configure.zcml
+++ b/ftw/simplelayout/aliasblock/browser/configure.zcml
@@ -10,4 +10,13 @@
         class=".aliasblock.AliasBlockView"
         />
 
+
+    <browser:viewlet
+        name="aliasblock.form"
+        for="*"
+        manager="ftw.simplelayout.interfaces.ISimplelayoutBlockFormManager"
+        layer="ftw.simplelayout.interfaces.ISimplelayoutLayer"
+        class=".viewlet.AliasBlockFormViewlet"
+        permission="zope2.View"
+        />
 </configure>

--- a/ftw/simplelayout/aliasblock/browser/templates/aliasblock_form_viewlet.pt
+++ b/ftw/simplelayout/aliasblock/browser/templates/aliasblock_form_viewlet.pt
@@ -1,0 +1,9 @@
+<div tal:condition="view/do_render_mapwidget">
+
+      <div id="aliasblock-map"
+           tal:define="geosettings python:context.restrictedTraverse('@@geosettings-view')"
+           class="blockwidget-cgmap"
+           tal:attributes="data-googlejs python:geosettings.google_maps_js;" />
+
+</div>
+

--- a/ftw/simplelayout/aliasblock/browser/viewlet.py
+++ b/ftw/simplelayout/aliasblock/browser/viewlet.py
@@ -1,0 +1,23 @@
+from ftw.simplelayout.aliasblock.contents.interfaces import IAliasBlock
+from plone import api
+from plone.app.layout.viewlets.common import ViewletBase
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from zope.component import queryMultiAdapter
+
+
+def geo_settings_installed():
+    version = api.portal.get().portal_setup.getLastVersionForProfile('collective.geo.settings:default')
+    return version != 'unknown'
+
+
+
+class AliasBlockFormViewlet(ViewletBase):
+    index = ViewPageTemplateFile('templates/aliasblock_form_viewlet.pt')
+
+    def update(self):
+        super(AliasBlockFormViewlet, self).update()
+
+        is_aliasblock = IAliasBlock.providedBy(self.context)
+        is_aliasblock_add_form = self.view.__name__ == 'ftw.simplelayout.AliasBlock'
+
+        self.do_render_mapwidget = (is_aliasblock or is_aliasblock_add_form) and geo_settings_installed()

--- a/ftw/simplelayout/tests/test_alias_block.py
+++ b/ftw/simplelayout/tests/test_alias_block.py
@@ -36,7 +36,7 @@ class TestAliasBlockRendering(TestCase):
             tofile='aliasblock'
         )
         output = list(diff)
-        if len(output) != 0:            
+        if len(output) != 0:
             self.fail('HTML differs:\n{}'.format('\n'.join(output)))
 
     @browsing
@@ -175,3 +175,18 @@ class TestAliasBlockRendering(TestCase):
         browser.login().visit(self.page2)
         self.assertEquals('The content is no longer accessible to you',
                           browser.css('.sl-alias-block p').first.text)
+
+    @browsing
+    def test_google_api_key_is_on_add_and_edit_form(self, browser):
+        browser.login().visit(self.page2, view='++add_block++ftw.simplelayout.AliasBlock')
+        browser.parse(browser.json['content'])
+        self.assertTrue(browser.css('[data-googlejs]'), 'Googlejs should be there.')
+
+        aliasblock = create(Builder('sl aliasblock')
+                            .having(alias=RelationValue(
+                                self.intids.getId(self.textblock)))
+                            .within(self.page2))
+
+        browser.visit(aliasblock, view='edit.json')
+        browser.parse(browser.json['content'])
+        self.assertTrue(browser.css('[data-googlejs]'), 'Googlejs should be there.')


### PR DESCRIPTION
This fixes the fowling JS error:

<img width="548" alt="Screen Shot 2020-06-08 at 09 17 26" src="https://user-images.githubusercontent.com/437933/84029577-e9bcb800-a992-11ea-8a7a-def6391518fe.png">
