### PR TITLE
Fix AliasBlock text for link to referenced ContentPage

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Do not allow to reference the ContentPage you are creating the AliasBlock on to prevent recursion [Nachtalb]
+- Fix AliasBlock text for link to referenced ContentPage [Nachtalb]
 
 
 2.7.0 (2020-06-10)

--- a/ftw/simplelayout/aliasblock/browser/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/browser/aliasblock.py
@@ -18,9 +18,12 @@ class AliasBlockView(BaseBlock):
     def has_view_permission(self):
         return api.user.has_permission('View', obj=self.referenced_obj)
 
+    def referece_is_page(self):
+        return ISimplelayout.providedBy(self.referenced_obj)
+
     def get_referenced_block_content(self):
         """Returns the rendered simplayout content"""
-        if ISimplelayout.providedBy(self.referenced_obj):
+        if self.referece_is_page():
             return self.get_referenced_page_content()
         else:
             return get_block_html(self.referenced_obj)

--- a/ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt
+++ b/ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt
@@ -6,10 +6,17 @@
 
   <tal:ref-valid condition="not: context/alias/isBroken">
     <tal:authorized condition="view/has_view_permission">
-      <a tal:attributes="href context/alias/to_path"
+      <a tal:condition="not: view/referece_is_page"
+         tal:attributes="href context/alias/to_path"
          class="sl-alias-block-visit-block"
          i18n:translate="label_visit_block">
         &#128279; Visit embedded block
+      </a>
+      <a tal:condition="view/referece_is_page"
+         tal:attributes="href context/alias/to_path"
+         class="sl-alias-block-visit-block"
+         i18n:translate="label_visit_page">
+        &#128279; Visit embedded page
       </a>
       <tal:alias-block content="structure view/get_referenced_block_content" />
     </tal:authorized>

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-10 12:47+0000\n"
+"POT-Creation-Date: 2020-06-10 11:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -602,12 +602,12 @@ msgid "label_internal_link"
 msgstr "Interne Referenz"
 
 #. Default: "The content is no longer accessible to you"
-#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:19
+#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:26
 msgid "label_invalid_permission"
 msgstr "Sie können leider nicht mehr auf den verwendeten Inhalt zugreifen."
 
 #. Default: "The embedded block does not exist."
-#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:23
+#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:30
 msgid "label_invalid_reference"
 msgstr "Der eingebettete Block existiert nicht."
 
@@ -708,6 +708,11 @@ msgstr "Video-URL"
 #: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:9
 msgid "label_visit_block"
 msgstr "&#128279; Zum Original-Block"
+
+#. Default: "&#128279; Visit embedded page"
+#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:15
+msgid "label_visit_page"
+msgstr "Zur Originalseite"
 
 #. Default: "height: ${height}px (current: ${current_height}px)"
 #: ./ftw/simplelayout/images/limits/validators.py:68

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -605,12 +605,12 @@ msgid "label_internal_link"
 msgstr ""
 
 #. Default: "The content is no longer accessible to you"
-#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:19
+#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:26
 msgid "label_invalid_permission"
 msgstr ""
 
 #. Default: "The embedded block does not exist."
-#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:23
+#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:30
 msgid "label_invalid_reference"
 msgstr ""
 
@@ -711,6 +711,11 @@ msgstr ""
 #: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:9
 msgid "label_visit_block"
 msgstr ""
+
+#. Default: "&#128279; Visit embedded page"
+#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:15
+msgid "label_visit_page"
+msgstr "Vers la page d'origine"
 
 #. Default: "height: ${height}px (current: ${current_height}px)"
 #: ./ftw/simplelayout/images/limits/validators.py:68

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -605,12 +605,12 @@ msgid "label_internal_link"
 msgstr ""
 
 #. Default: "The content is no longer accessible to you"
-#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:19
+#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:26
 msgid "label_invalid_permission"
 msgstr ""
 
 #. Default: "The embedded block does not exist."
-#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:23
+#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:30
 msgid "label_invalid_reference"
 msgstr ""
 
@@ -710,6 +710,11 @@ msgstr ""
 #. Default: "&#128279; Visit embedded block"
 #: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:9
 msgid "label_visit_block"
+msgstr ""
+
+#. Default: "&#128279; Visit embedded page"
+#: ./ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt:15
+msgid "label_visit_page"
 msgstr ""
 
 #. Default: "height: ${height}px (current: ${current_height}px)"


### PR DESCRIPTION
When we reference a page we shouldn't tell the user that it is a block. 
![image](https://user-images.githubusercontent.com/9467802/84265879-e1e04d80-ab23-11ea-8f28-d3e52fabbd4b.png)
