### PR TITLE
Prevent recursion when creating an AliasBlock

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Do not allow to reference the ContentPage you are creating the AliasBlock on to prevent recursion [Nachtalb]
 
 
 2.7.0 (2020-06-10)

--- a/ftw/simplelayout/aliasblock/contents/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/contents/aliasblock.py
@@ -4,6 +4,7 @@ from ftw.referencewidget.widget import ReferenceBrowserWidget
 from ftw.simplelayout import _
 from ftw.simplelayout.aliasblock.contents.interfaces import IAliasBlock
 from plone import api
+from plone.uuid.interfaces import IUUID
 from plone.autoform.interfaces import IFormFieldProvider
 from plone.dexterity.content import Item
 from plone.directives import form
@@ -26,6 +27,8 @@ class AliasBlockSelectable(DefaultSelectable):
 
         # Don't allow sl pages containing another AliasBlock
         if is_sl_page:
+            if IUUID(self.content) == IUUID(self.source.context):
+                return False
             return not bool(filter(
                 lambda item: item.portal_type == 'ftw.simplelayout.AliasBlock',
                 self.content.objectValues()
@@ -83,7 +86,7 @@ class ContentPageValidator(validator.SimpleFieldValidator):
             if value.portal_type == 'ftw.simplelayout.ContentPage':
                 raise Invalid(
                     _(u'error_text_sl_page_aliasblock',
-                      default=u'The selected ContentPage contains a Aliasblock and cannot be selected'))
+                      default=u'The selected ContentPage contains a Aliasblock or is the page you are creating the block on and thus cannot be selected'))
             else:
                 raise Invalid(
                     _(u'error_text_alias_aliasblock',

--- a/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-10 06:15+0000\n"
+"POT-Creation-Date: 2020-06-10 12:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -400,20 +400,19 @@ msgid "description_teaser_fieldset"
 msgstr "Mit der Link-Funktion kann ein Block direkt mit weiterführendem Inhalt verknüpft werden.<br /> Der Titel und das Bild vom Block werden als Link mit dem Ziel verknüpft.<br /><br /> Oft wird die Linkfunktion auch auf sogenannten Triage- oder Portal-Seiten verwendet. In diesen Fällen reicht ein Link in der Navigation nicht aus, sondern der Benutzer benötigt weitere Informationen, damit dieser auf der richten Seite landet."
 
 #. Default: "The selected content cannot be selected"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:89
-#, fuzzy
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:92
 msgid "error_text_alias_aliasblock"
 msgstr "Der ausgwählte Inhalt kann nicht als Ziel in einem AliasBlock verwendet werden"
 
 #. Default: "A input is required"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:78
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:81
 msgid "error_text_required_aliasblock"
 msgstr "Es muss ein Ziel ausgewählt werden."
 
-#. Default: "The selected ContentPage contains a Aliasblock and cannot be selected"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:85
+#. Default: "The selected ContentPage contains a Aliasblock or is the page you are creating the block on and thus cannot be selected"
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:88
 msgid "error_text_sl_page_aliasblock"
-msgstr "Die ausgwählte Inhlatsseite kann nicht verwendet werden, da diese bereits einen AliasBlock enthält."
+msgstr "Die ausgwählte Inhlatsseite kann nicht verwendet werden, da diese bereits einen AliasBlock enthält oder die Seite ist auf welcher sie den Block erstellen."
 
 #: ./ftw/simplelayout/aliasblock/configure.zcml:24
 msgid "ftw.simplelayout aliasblock default"
@@ -468,12 +467,12 @@ msgid "label_%ssort_index"
 msgstr "Sortierung"
 
 #. Default: "Alias Content"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:57
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:60
 msgid "label_alias_content"
 msgstr "Alias Inhalt"
 
 #. Default: "Choose a block to be rendered within this block."
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:59
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:62
 msgid "label_alias_description"
 msgstr "Wähle den Block, der im AliasBlock angezeigt werden soll."
 

--- a/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
+++ b/ftw/simplelayout/locales/fr/LC_MESSAGES/ftw.simplelayout.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-10 06:15+0000\n"
+"POT-Creation-Date: 2020-06-10 12:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -403,17 +403,17 @@ msgid "description_teaser_fieldset"
 msgstr ""
 
 #. Default: "The selected content cannot be selected"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:89
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:92
 msgid "error_text_alias_aliasblock"
 msgstr ""
 
 #. Default: "A input is required"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:78
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:81
 msgid "error_text_required_aliasblock"
 msgstr ""
 
-#. Default: "The selected ContentPage contains a Aliasblock and cannot be selected"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:85
+#. Default: "The selected ContentPage contains a Aliasblock or is the page you are creating the block on and thus cannot be selected"
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:88
 msgid "error_text_sl_page_aliasblock"
 msgstr ""
 
@@ -470,12 +470,12 @@ msgid "label_%ssort_index"
 msgstr ""
 
 #. Default: "Alias Content"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:57
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:60
 msgid "label_alias_content"
 msgstr ""
 
 #. Default: "Choose a block to be rendered within this block."
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:59
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:62
 msgid "label_alias_description"
 msgstr ""
 

--- a/ftw/simplelayout/locales/ftw.simplelayout.pot
+++ b/ftw/simplelayout/locales/ftw.simplelayout.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2020-06-10 06:15+0000\n"
+"POT-Creation-Date: 2020-06-10 12:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -403,17 +403,17 @@ msgid "description_teaser_fieldset"
 msgstr ""
 
 #. Default: "The selected content cannot be selected"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:89
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:92
 msgid "error_text_alias_aliasblock"
 msgstr ""
 
 #. Default: "A input is required"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:78
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:81
 msgid "error_text_required_aliasblock"
 msgstr ""
 
-#. Default: "The selected ContentPage contains a Aliasblock and cannot be selected"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:85
+#. Default: "The selected ContentPage contains a Aliasblock or is the page you are creating the block on and thus cannot be selected"
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:88
 msgid "error_text_sl_page_aliasblock"
 msgstr ""
 
@@ -470,12 +470,12 @@ msgid "label_%ssort_index"
 msgstr ""
 
 #. Default: "Alias Content"
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:57
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:60
 msgid "label_alias_content"
 msgstr ""
 
 #. Default: "Choose a block to be rendered within this block."
-#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:59
+#: ./ftw/simplelayout/aliasblock/contents/aliasblock.py:62
 msgid "label_alias_description"
 msgstr ""
 

--- a/ftw/simplelayout/tests/test_alias_block.py
+++ b/ftw/simplelayout/tests/test_alias_block.py
@@ -124,7 +124,23 @@ class TestAliasBlockRendering(TestCase):
         browser.find_button_by_label('Save').click()
         self.assertEquals(['There were some errors.'],
                           statusmessages.error_messages())
-        self.assertEquals('The selected ContentPage contains a Aliasblock and cannot be selected',
+        self.assertEquals('The selected ContentPage contains a Aliasblock or is the '
+                          'page you are creating the block on and thus cannot be selected',
+                          browser.css('#formfield-form-widgets-alias .error').first.text)
+
+    @browsing
+    def test_dont_allow_creating_block_on_current_page(self, browser):
+        browser.login().visit(self.page1)
+        factoriesmenu.add('AliasBlock')
+
+        form = browser.find_form_by_field('Alias Content')
+        form.find_widget('Alias Content').fill(self.page1)
+
+        browser.find_button_by_label('Save').click()
+        self.assertEquals(['There were some errors.'],
+                          statusmessages.error_messages())
+        self.assertEquals('The selected ContentPage contains a Aliasblock or is the '
+                          'page you are creating the block on and thus cannot be selected',
                           browser.css('#formfield-form-widgets-alias .error').first.text)
 
     @browsing


### PR DESCRIPTION
by forbidding referencing the ContenPage you are creating the block on.