### PR TITLE
Fix link to referenced object

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix link to referenced object [Nachtalb]
 
 
 2.7.2 (2020-06-12)

--- a/ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt
+++ b/ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt
@@ -7,13 +7,13 @@
   <tal:ref-valid condition="not: context/alias/isBroken">
     <tal:authorized condition="view/has_view_permission">
       <a tal:condition="not: view/referece_is_page"
-         tal:attributes="href context/alias/to_path"
+         tal:attributes="href context/alias/to_object/absolute_url"
          class="sl-alias-block-visit-block"
          i18n:translate="label_visit_block">
         &#128279; Visit embedded block
       </a>
       <a tal:condition="view/referece_is_page"
-         tal:attributes="href context/alias/to_path"
+         tal:attributes="href context/alias/to_object/absolute_url"
          class="sl-alias-block-visit-block"
          i18n:translate="label_visit_page">
         &#128279; Visit embedded page <span class="page-title" i18n:name="page_title" tal:content="context/alias/to_object/Title" />


### PR DESCRIPTION
`to_path` does not take urls and starting at a different path into
account so we use `absolute_url()` which does.