### PR TITLE
Remove obsolete extras

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 ------------------
 
 - Fix link to referenced object [Nachtalb]
+- Remove ``aliasblock`` and ``contenttypes`` conditions because empty extras cannot be checked [Nachtalb]
 
 
 2.7.2 (2020-06-12)

--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -29,7 +29,7 @@
 
     <include package=".contenttypes" />
     <include package=".mapblock" zcml:condition="have ftw.simplelayout:mapblock" />
-    <include package=".aliasblock" zcml:condition="have ftw.simplelayout:aliasblock" />
+    <include package=".aliasblock" />
     <include package=".restapi" zcml:condition="installed plone.restapi" />
 
     <cmf:registerDirectory

--- a/ftw/simplelayout/configure.zcml
+++ b/ftw/simplelayout/configure.zcml
@@ -27,9 +27,9 @@
     <include file="lawgiver.zcml" zcml:condition="installed ftw.lawgiver" />
     <include file="resources.zcml" zcml:condition="installed ftw.theming" />
 
-    <include package=".contenttypes" zcml:condition="have ftw.simplelayout:contenttypes" />
-    <include package=".mapblock" zcml:condition="have ftw.simplelayout:contenttypes:mapblock" />
-    <include package=".aliasblock" zcml:condition="have ftw.simplelayout:contenttypes:aliasblock" />
+    <include package=".contenttypes" />
+    <include package=".mapblock" zcml:condition="have ftw.simplelayout:mapblock" />
+    <include package=".aliasblock" zcml:condition="have ftw.simplelayout:aliasblock" />
     <include package=".restapi" zcml:condition="installed plone.restapi" />
 
     <cmf:registerDirectory

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,6 @@ extras_require = {
     'trash': [
         'ftw.trash',
     ],
-    'aliasblock': [
-        # Use ftw.autofeature to automatically add aliasblock
-    ],
 }
 
 

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -4,7 +4,7 @@ extends =
     sources.cfg
 
 package-name = ftw.simplelayout
-test-egg = ftw.simplelayout [tests, mapblock, plone4, aliasblock]
+test-egg = ftw.simplelayout [tests, mapblock, plone4]
 
 [versions]
 collective.geo.behaviour = 1.2

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -4,7 +4,7 @@ extends =
     sources.cfg
 
 package-name = ftw.simplelayout
-test-egg = ftw.simplelayout [tests, mapblock, aliasblock]
+test-egg = ftw.simplelayout [tests, mapblock]
 
 [versions]
 ftw.upgrade = 2.9.0


### PR DESCRIPTION
The condition used in the zcml comes from ftw.autofeature which actually
does not detect if the extra is installed but if all dependencies of the
extra are installed. Thus it will also result to `True` for extras that
don't have a dependency.

Both `contenttypes` and `aliasblock` extras are empty so the conditions were all for naught. 