### PR TITLE
Add ftw.logo support for plone root opengraph integration.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add ftw.logo support for plone root opengraph integration. [mathias.leimgruber]
 
 
 2.7.3 (2020-06-15)

--- a/ftw/simplelayout/opengraph/configure.zcml
+++ b/ftw/simplelayout/opengraph/configure.zcml
@@ -12,6 +12,11 @@
     </class>
 
     <adapter factory=".og_site_root.PloneRootOpenGraph" name="opengraph" />
+
+    <configure zcml:condition="installed ftw.logo">
+        <include package=".ftwlogo" />
+    </configure>
+
     <adapter factory=".og_sl_page.SimplelayoutPageOpenGraph" name="opengraph" />
 
     <browser:viewlet

--- a/ftw/simplelayout/opengraph/ftwlogo/configure.zcml
+++ b/ftw/simplelayout/opengraph/ftwlogo/configure.zcml
@@ -1,0 +1,7 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
+
+    <adapter factory=".og_ftw_logo.FtwLogoRootOpenGraph" name="opengraph" />
+
+</configure>

--- a/ftw/simplelayout/opengraph/ftwlogo/og_ftw_logo.py
+++ b/ftw/simplelayout/opengraph/ftwlogo/og_ftw_logo.py
@@ -1,0 +1,26 @@
+from ftw.logo.interfaces import IFtwLogo
+from ftw.simplelayout.opengraph.og_site_root import PloneRootOpenGraph
+from plone import api
+from plone.app.caching.interfaces import IETagValue
+from Products.CMFPlone.interfaces import IPloneSiteRoot
+from zope.component import adapts
+from zope.component import getMultiAdapter
+from zope.interface import Interface
+
+
+class FtwLogoRootOpenGraph(PloneRootOpenGraph):
+    adapts(IPloneSiteRoot, IFtwLogo, Interface)
+
+    def get_cache_key(self):
+        adapter = getMultiAdapter((api.portal.get(), self.request),
+                                  IETagValue,
+                                  name='logo-viewlet')
+        return adapter()
+
+    def get_image_url(self):
+        """ftw.logo image"""
+
+        return '{}/@@logo/logo/get_logor={}'.format(
+            api.portal.get().absolute_url(),
+            self.get_cache_key()
+        )

--- a/ftw/simplelayout/tests/test_opengraph.py
+++ b/ftw/simplelayout/tests/test_opengraph.py
@@ -115,3 +115,14 @@ class TestOpenGraph(TestCase):
         page_config = IPageConfiguration(page)
         page_config.store(self.page_state)
         transaction.commit()
+
+    @browsing
+    def test_opengraph_ftwlogo_integration(self, browser):
+        self.portal.portal_setup.runAllImportStepsFromProfile('profile-ftw.logo:default')
+        transaction.commit()
+        browser.login().visit()
+
+        logo_url_without_cache = '{}/@@logo/logo/get_logo'.format(self.portal.absolute_url())
+
+        og_image = browser.css('meta[property="og:image"]').first.attrib['content']
+        self.assertTrue(og_image.startswith(logo_url_without_cache))

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ tests_require = [
     'transaction',
     'zope.configuration',
     'ftw.simplelayout [trash, mapblock]',
+    'ftw.logo',
 ]
 
 extras_require = {


### PR DESCRIPTION
- ftw.simplelayout has now a soft dep on ftw.logo.
- This fixes the opengraph integration if both are installed. Before og:image returned the hard coded logo.jpg.