### PR TITLE
Fix ftw.logo opengraph integration

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ftw.logo opengraph integration [Nachtalb]
 
 
 2.7.4 (2020-06-19)

--- a/ftw/simplelayout/opengraph/ftwlogo/og_ftw_logo.py
+++ b/ftw/simplelayout/opengraph/ftwlogo/og_ftw_logo.py
@@ -20,7 +20,7 @@ class FtwLogoRootOpenGraph(PloneRootOpenGraph):
     def get_image_url(self):
         """ftw.logo image"""
 
-        return '{}/@@logo/logo/get_logor={}'.format(
+        return '{}/@@logo/logo/get_logo?r={}'.format(
             api.portal.get().absolute_url(),
             self.get_cache_key()
         )

--- a/ftw/simplelayout/tests/test_opengraph.py
+++ b/ftw/simplelayout/tests/test_opengraph.py
@@ -125,4 +125,5 @@ class TestOpenGraph(TestCase):
         logo_url_without_cache = '{}/@@logo/logo/get_logo'.format(self.portal.absolute_url())
 
         og_image = browser.css('meta[property="og:image"]').first.attrib['content']
+        browser.open(og_image)
         self.assertTrue(og_image.startswith(logo_url_without_cache))


### PR DESCRIPTION
The `?` to mark the `r=XXXXXX` as a query parameter was missing. The test succeeded because we did not check the query params nor if the URL actually works. Now we do check the URL by opening it (without the `?` it returns a 404 and the test fails)