### PR TITLE
Fix tinymce prependToUrl value, in order to make internal links work on plone root.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix tinymce prependToUrl value, in order to make internal links work on plone root. [mathias.leimgruber]
 
 
 2.7.6 (2020-07-01)

--- a/ftw/simplelayout/browser/configure.zcml
+++ b/ftw/simplelayout/browser/configure.zcml
@@ -61,4 +61,15 @@
             permission="cmf.ModifyViewTemplate"
             />
     </configure>
+
+    <!-- Adapters for patterns settings -->
+    <configure zcml:condition="have plone-5">
+        <adapter
+            factory=".tinymce.SimplelayoutPatternSettingsAdapter"
+            for="* ftw.simplelayout.interfaces.ISimplelayoutLayer *"
+            name="plone_settings"
+            provides="Products.CMFPlone.interfaces.IPatternsSettings"
+            />
+    </configure>
+
 </configure>

--- a/ftw/simplelayout/browser/tinymce.py
+++ b/ftw/simplelayout/browser/tinymce.py
@@ -1,0 +1,15 @@
+from Products.CMFPlone.interfaces import IPatternsSettings
+from Products.CMFPlone.patterns.settings import PatternSettingsAdapter
+from zope.interface import implementer
+import json
+
+
+@implementer(IPatternsSettings)
+class SimplelayoutPatternSettingsAdapter(PatternSettingsAdapter):
+    def tinymce(self):
+        config = super(SimplelayoutPatternSettingsAdapter, self).tinymce()
+        data_config = json.loads(config['data-pat-tinymce'])
+
+        # Original 'prependToUrl': '{0}/resolveuid/'.format(site_path.rstrip('/')),
+        data_config['prependToUrl'] = 'resolveuid/'
+        return {'data-pat-tinymce': json.dumps(data_config)}

--- a/ftw/simplelayout/tests/test_content_types.py
+++ b/ftw/simplelayout/tests/test_content_types.py
@@ -3,11 +3,14 @@ from ftw.builder import create
 from ftw.simplelayout.interfaces import IBlockConfiguration
 from ftw.simplelayout.interfaces import IBlockModifier
 from ftw.simplelayout.testing import FTW_SIMPLELAYOUT_CONTENT_TESTING
+from ftw.simplelayout.utils import IS_PLONE_5
 from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import factoriesmenu
 from ftw.testbrowser.pages import plone
+from unittest import skipUnless
 from unittest import TestCase
 from zope.component import getMultiAdapter
+import json
 
 
 class TestSampleTypes(TestCase):
@@ -62,3 +65,14 @@ class TestSampleTypes(TestCase):
         self.assertEqual(
             ['A page'],
             browser.css('.documentFirstHeading').text)
+
+    @browsing
+    @skipUnless(IS_PLONE_5, 'Only testable on plone 5')
+    def test_patterns_lib_tinymce_config_prependToUrl(self, browser):
+        browser.login().visit(self.portal)
+        factoriesmenu.add('TextBlock')
+        tiny_settings = json.loads(
+            browser.css('.richtext-field').first.attrib['data-pat-tinymce']
+        )
+
+        self.assertEquals('resolveuid/', tiny_settings['prependToUrl'])


### PR DESCRIPTION
Otherwise on the plone root internal links are broken resp. composed like: `/Plone/resolveuid/...`, which does not get caught by the regex from plone.outputfilters, which expect the relative url to start with a `./` --> `resolveuid_re = re.compile('^[./]*resolve[Uu]id/([^/]*)/?(.*)$')`
