### PR TITLE
Escape special chars for opengraph title and description.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Escape special chars for opengraph title and description. [mathias.leimgruber] 
 
 
 2.7.9 (2020-08-05)

--- a/ftw/simplelayout/opengraph/og_site_root.py
+++ b/ftw/simplelayout/opengraph/og_site_root.py
@@ -42,9 +42,24 @@ class PloneRootOpenGraph(object):
         return registry.forInterface(
             ISimplelayoutDefaultSettings, check=False)
 
+    def _escape(self, text):
+        """More or less taken from https://wiki.python.org/moin/EscapingHtml
+        """
+        html_escape_table = OrderedDict([
+            ("&", "&amp;"),
+            ('"', "&quot;"),
+            ("'", "&apos;"),
+            (">", "&gt;"),
+            ("<", "&lt;"),
+        ])
+
+        for sign in html_escape_table.items():
+            text = text.replace(*sign)
+        return text
+
     def get_title(self):
         """OG Title"""
-        return api.portal.get().Title().decode('utf-8')
+        return self._escape(api.portal.get().Title().decode('utf-8'))
 
     def get_type(self):
         """OG type"""
@@ -65,7 +80,7 @@ class PloneRootOpenGraph(object):
 
     def get_description(self):
         """OG description"""
-        return api.portal.get().Description().decode('utf-8')
+        return self._escape(api.portal.get().Description().decode('utf-8'))
 
     def get_fb_app_id(self):
         """FB app ID"""

--- a/ftw/simplelayout/opengraph/og_sl_page.py
+++ b/ftw/simplelayout/opengraph/og_sl_page.py
@@ -25,7 +25,7 @@ class SimplelayoutPageOpenGraph(PloneRootOpenGraph):
 
     def get_title(self):
         """OG Title"""
-        return self.context.title_or_id()
+        return self._escape(self.context.title_or_id())
 
     def get_url(self):
         """OG url"""
@@ -42,8 +42,8 @@ class SimplelayoutPageOpenGraph(PloneRootOpenGraph):
 
     def get_site_name(self):
         """OG site name"""
-        return api.portal.get().Title().decode('utf-8')
+        return self._escape(api.portal.get().Title().decode('utf-8'))
 
     def get_description(self):
         """OG description"""
-        return self.context.Description().decode('utf-8')
+        return self._escape(self.context.Description().decode('utf-8'))

--- a/ftw/simplelayout/tests/test_opengraph.py
+++ b/ftw/simplelayout/tests/test_opengraph.py
@@ -32,6 +32,9 @@ class TestOpenGraph(TestCase):
 
     @browsing
     def test_og_on_plone_root(self, browser):
+        browser.exception_bubbling = True
+        api.portal.get().manage_changeProperties(
+            {'Title': '"<>& Seite title'})
         browser.login().visit()
 
         self.assertOg('og:title', api.portal.get().Title())
@@ -60,10 +63,13 @@ class TestOpenGraph(TestCase):
 
     @browsing
     def test_og_on_simplelayout_page(self, browser):
-        page = create(Builder('sl content page').titled(u'\xfc Title'))
+        page = create(Builder('sl content page')
+                      .titled(u'\xfc Title "<>&')
+                      .having(description=u"Description '<>&"))
         browser.login().visit(page)
 
         self.assertOg('og:title', page.Title().decode('utf-8'))
+        self.assertOg('og:description', page.Description().decode('utf-8'))
         self.assertOg('og:url', page.absolute_url())
         self.assertOg('og:type', u'website')
         self.assertOg('og:image', self.portal.absolute_url() + '/logo.jpg')


### PR DESCRIPTION
Since we don't use TAL to render the content some signs need to be escaped.

Example if somebody used a double quote in the description:
<img width="1674" alt="Screen Shot 2020-08-13 at 15 52 42" src="https://user-images.githubusercontent.com/437933/90150740-41f2aa80-dd86-11ea-99da-f116e39c0a04.png">

I adjusted the test data. The assertions do not change since the test browser unescapes those signs again.
But the test would fail with the new data and without the changes.
