### PR TITLE
Fix link integrity check on Plone 5

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.7.11 (unreleased)
 -------------------
 
-- Escape special chars for opengraph title and description. [mathias.leimgruber] 
+- Escape special chars for opengraph title and description. [mathias.leimgruber]
+- Fix link integrity check on Plone 5 [Nachtalb]
 
 
 2.7.10 (2020-08-20)

--- a/ftw/simplelayout/browser/ajax/delete_blocks.py
+++ b/ftw/simplelayout/browser/ajax/delete_blocks.py
@@ -51,6 +51,7 @@ class DeleteBlocks(BrowserView):
 
     def get_link_integrity_breaches(self):
         if isLinked(self.block):
+            breaches_info = []
 
             if IS_PLONE_5:
                 portal = api.portal.get()
@@ -58,17 +59,18 @@ class DeleteBlocks(BrowserView):
                     'delete_confirmation_info',
                     portal,
                     self.request)
-                breaches = view.get_breaches([self.block, ])
+                sources = view.get_breaches([self.block, ])[0]['sources']
+                for source in sources:
+                    breaches_info.append({'title': source['title'],
+                                          'url': source['url']})
             else:
                 breaches = self.link_integrity.getIntegrityBreaches()
+                sources = breaches.values()
+                sources = len(sources) and sources[0] or sources
 
-            breaches_info = []
-            sources = breaches.values()
-            sources = len(sources) and sources[0] or sources
-
-            for source in sources:
-                breaches_info.append({'title': source.title_or_id(),
-                                      'url': source.absolute_url()})
+                for source in sources:
+                    breaches_info.append({'title': source.title_or_id(),
+                                          'url': source.absolute_url()})
 
             return breaches_info
         else:


### PR DESCRIPTION
In Plone 4 we get a dict. In Plone 5 we get a list of dicts because the API allows for checking multiple objects at once. https://4teamwork.atlassian.net/browse/OGB-624