### PR TITLE
Remove margin from sl images on small screens

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 2.7.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove left and right margin from 100% wide sl-image on small screens (< 480px)
+  [djowett-ftw]
 
 
 2.7.11 (2020-09-08)

--- a/ftw/simplelayout/browser/resources/integration.theme.scss
+++ b/ftw/simplelayout/browser/resources/integration.theme.scss
@@ -187,15 +187,17 @@
   .sl-image {
     margin-bottom: $margin-paragraph-vertical;
 
-    &.left {
-      margin-right: $margin-paragraph-vertical;
-    }
-
-    &.right {
-      margin-left: $margin-paragraph-vertical;
-    }
     .image-caption {
       text-align: center;
+    }
+    @include screen-small() {
+      &.left {
+        margin-right: $margin-paragraph-vertical;
+      }
+
+      &.right {
+        margin-left: $margin-paragraph-vertical;
+      }
     }
   }
 }


### PR DESCRIPTION
These images are 100% wide on small screens (see line 128 and following), so they don't need margin there.

This might seem wide-ranging, but it's the right place to clear it up IMO, 
when would we really want to have margins on 100% width images?

For https://4teamwork.atlassian.net/browse/OGB-672

before

![Screenshot 2020-09-08 at 16 38 31](https://user-images.githubusercontent.com/54800639/92490874-d5869200-f1f1-11ea-8459-ba73b087fe50.png)


after

![Screenshot 2020-09-08 at 16 37 37](https://user-images.githubusercontent.com/54800639/92490894-dc150980-f1f1-11ea-89bd-1f6faa0cc344.png)
