### PR TITLE
Not necessary to add the plain IGeoreferenceable interface as a behavior 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove non behavior interface from FTI. [djowett-ftw]
 
 
 2.7.12 (2020-09-08)

--- a/ftw/simplelayout/mapblock/profiles/default_plone5/types/ftw.simplelayout.MapBlock.xml
+++ b/ftw/simplelayout/mapblock/profiles/default_plone5/types/ftw.simplelayout.MapBlock.xml
@@ -27,7 +27,6 @@
         <element value="plone.app.content.interfaces.INameFromTitle" />
         <element value="ftw.simplelayout.interfaces.ISimplelayoutBlock" />
         <element value="ftw.simplelayout.mapblock.behavior.IBlockCoordinates" />
-        <element value="collective.geo.geographer.interfaces.IGeoreferenceable" />
     </property>
 
     <!-- View information -->

--- a/ftw/simplelayout/mapblock/upgrades/20200910161137_remove_non_behavior_interface_from_fti/types/ftw.simplelayout.MapBlock.xml
+++ b/ftw/simplelayout/mapblock/upgrades/20200910161137_remove_non_behavior_interface_from_fti/types/ftw.simplelayout.MapBlock.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<object name="ftw.simplelayout.MapBlock"
+        meta_type="Dexterity FTI"
+        xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+        i18n:domain="ftw.simplelayout" >
+
+    <property name="behaviors" purge="False">
+        <element value="collective.geo.geographer.interfaces.IGeoreferenceable" remove="True"/>
+    </property>
+
+</object>

--- a/ftw/simplelayout/mapblock/upgrades/20200910161137_remove_non_behavior_interface_from_fti/upgrade.py
+++ b/ftw/simplelayout/mapblock/upgrades/20200910161137_remove_non_behavior_interface_from_fti/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class RemoveNonBehaviorInterfaceFromFTI(UpgradeStep):
+    """Remove non behavior interface from FTI.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
... if IBlockCoordinates is there

This is deprecated and produces the warning:
```
        plone.dexterity.schema No behavior registration found for behavior named: 'collective.geo.geographer.interfaces.IGeoreferenceable'
```
which got raised as something to be fixed in bl.web (see https://4teamwork.atlassian.net/browse/OGB-708)


 
IBlockCoordinates adds IGeoreferenceable as a marker interface anyway