### PR TITLE
AliasBlock rendering improvements. 

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,7 @@ Changelog
 
 - Fix layout/column in aliasblock results in failure [Nachtalb]
 - Aliasblock: Show hint to target block/page if you can edit the current aliasblock. [mathias.leimgruber]
+- Aliasblock: Access to_object/isBroken only if there is a RelationValue. [mathias.leimgruber]
 
 
 1.26.3 (2020-07-30)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Fix layout/column in aliasblock results in failure [Nachtalb]
+- Aliasblock: Show hint to target block/page if you can edit the current aliasblock. [mathias.leimgruber]
 
 
 1.26.3 (2020-07-30)

--- a/ftw/simplelayout/aliasblock/browser/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/browser/aliasblock.py
@@ -20,7 +20,7 @@ class AliasBlockView(BaseBlock):
         return api.user.has_permission('View', obj=self.referenced_obj)
 
     def can_modify(self):
-        return api.user.has_permission('Modify portal content', obj=self.referenced_obj)
+        return api.user.has_permission('Modify portal content', obj=self.context)
 
     def referece_is_page(self):
         return ISimplelayout.providedBy(self.referenced_obj)

--- a/ftw/simplelayout/aliasblock/browser/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/browser/aliasblock.py
@@ -14,9 +14,13 @@ class AliasBlockView(BaseBlock):
 
     def __init__(self, context, request):
         super(AliasBlockView, self).__init__(context, request)
-        self.referenced_obj = self.context.alias.to_object
+        alias = self.context.alias
+        self.referenced_obj = alias and alias.to_object or None
 
     def has_view_permission(self):
+        if not self.referenced_obj or self.context.alias.isBroken():
+            return False
+
         return api.user.has_permission('View', obj=self.referenced_obj)
 
     def can_modify(self):

--- a/ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt
+++ b/ftw/simplelayout/aliasblock/browser/templates/aliasblock.pt
@@ -3,9 +3,8 @@
       i18n:domain="ftw.simplelayout">
 
 <div class="sl-alias-block"
-      tal:attributes="class python:not context.alias.isBroken() and view.has_view_permission() and 'sl-alias-block' or 'sl-alias-block no-access'">
+      tal:attributes="class python:view.has_view_permission() and 'sl-alias-block' or 'sl-alias-block no-access'">
 
-  <tal:ref-valid condition="not: context/alias/isBroken">
     <tal:authorized condition="view/has_view_permission">
       <tal:authenticated condition="view/can_modify">
         <a tal:condition="not: view/referece_is_page"
@@ -23,16 +22,10 @@
       </tal:authenticated>
       <div tal:attributes="class view/get_css_classes" tal:content="structure view/get_referenced_block_content" />
     </tal:authorized>
-  </tal:ref-valid>
 
   <tal:not-authorized condition="not: view/has_view_permission">
     <p i18n:translate="label_invalid_permission">The content is no longer accessible to you</p>
   </tal:not-authorized>
-
-  <tal:ref-invalid condition="context/alias/isBroken">
-    <p i18n:translate="label_invalid_reference">The embedded block does not exist.</p>
-  </tal:ref-invalid>
-
 </div>
 
 </html>

--- a/ftw/simplelayout/tests/test_alias_block.py
+++ b/ftw/simplelayout/tests/test_alias_block.py
@@ -88,7 +88,7 @@ class TestAliasBlockRendering(TestCase):
         browser.visit(self.page2)
         block_content = browser.css('.sl-alias-block').first.text
 
-        self.assertEqual(u'The embedded block does not exist.', block_content)
+        self.assertEqual(u'The content is no longer accessible to you', block_content)
 
     @browsing
     def test_custom_selectable_implementation(self, browser):


### PR DESCRIPTION
This basically avoids completely from having issues rendering the block. 

Either "he content is no longer accessible to you" or "The embedded block does not exist." will be displayed.
A failure while rendering the block does not happen anymore.

Before the code usually broke when it tried to access `isBroken` or `to_object` of None type value. 