### PR TITLE
Fix loading jquery 2 times and with this creating conflicts

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Remove non behavior interface from FTI. [djowett-ftw]
+- Fix loading jquery 2 times and with this creating conflicts [Nachtalb]
 
 
 2.7.12 (2020-09-08)

--- a/ftw/simplelayout/contenttypes/profiles/default_plone5/registry.xml
+++ b/ftw/simplelayout/contenttypes/profiles/default_plone5/registry.xml
@@ -46,6 +46,7 @@
   <records prefix="plone.bundles/ftw-simplelayout-contenttype"
            interface='Products.CMFPlone.interfaces.IBundleRegistry'>
     <value key="enabled">True</value>
+    <value key="depends">plone</value>
     <value key="stub_js_modules">jquery</value>
     <value key="compile">False</value>
     <value key="jscompilation">++plone++ftw.simplelayout/simplelayout-contenttype-compiled.js</value>

--- a/ftw/simplelayout/contenttypes/upgrades/20200929161226_fix_contenttype_jquery_dependency/registry.xml
+++ b/ftw/simplelayout/contenttypes/upgrades/20200929161226_fix_contenttype_jquery_dependency/registry.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<registry>
+  <records prefix="plone.bundles/ftw-simplelayout-contenttype"
+           interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+    <value key="depends">plone</value>
+  </records>
+</registry>

--- a/ftw/simplelayout/contenttypes/upgrades/20200929161226_fix_contenttype_jquery_dependency/upgrade.py
+++ b/ftw/simplelayout/contenttypes/upgrades/20200929161226_fix_contenttype_jquery_dependency/upgrade.py
@@ -1,0 +1,9 @@
+from ftw.upgrade import UpgradeStep
+
+
+class FixContenttypeJqueryDependency(UpgradeStep):
+    """Fix contenttype jquery dependency.
+    """
+
+    def __call__(self):
+        self.install_upgrade_profile()


### PR DESCRIPTION
Without the depends on plone our JS was loaded before the
plone-compiled JS. This somehow resulted in require.js loading the
jQuery a second time even though jQuery was already present. Why exactly
this happens and why loading plone as the first script fixes this we
don't know - but it does.