### PR TITLE
Move objects to the target if they are created within the working copy.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.26.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Staging: Move instead of copy blocks, which were created in the working copy, in
+  order to preserve the UID. Otherwise internal links within the working copy no longer work. [mathias.leimgruber]
 
 
 1.26.4 (2020-09-16)

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -293,6 +293,7 @@ class Staging(object):
         uuid_map = uuid_map or {}
         uuid_map[IUUID(source)] = IUUID(target)
         target_children_map = {IUUID(obj): obj for obj in self._get_children(target, condition)}
+        source_ids = source.objectIds()
         self._copy_field_values(source, target)
         self._purge_scales(target)
         self._update_simplelayout_block_state(source, target)
@@ -303,10 +304,10 @@ class Staging(object):
                 target_child = target_children_map.pop(target_uid)
                 self._apply_children(source_child, target_child, uuid_map=uuid_map)
             else:
-                target_child = self._copy_new_obj(source_child, target)
+                target_child = self._move_new_obj(source_child, target)
                 uuid_map[IUUID(source_child)] = IUUID(target_child)
 
-        target.moveObjectsToTop(source.objectIds())
+        target.moveObjectsToTop(source_ids)
         target.manage_delObjects(map(methodcaller('getId'), target_children_map.values()))
         return uuid_map
 
@@ -421,8 +422,8 @@ class Staging(object):
         for schema in getAdditionalSchemata(portal_type=portal_type):
             yield schema
 
-    def _copy_new_obj(self, obj, new_parent):
-        clipboard = aq_parent(aq_inner(obj)).manage_copyObjects([obj.getId()])
+    def _move_new_obj(self, obj, new_parent):
+        clipboard = aq_parent(aq_inner(obj)).manage_cutObjects([obj.getId()])
         info = new_parent.manage_pasteObjects(clipboard)
         return new_parent.get(info[0]['new_id'])
 

--- a/ftw/simplelayout/tests/test_staging.py
+++ b/ftw/simplelayout/tests/test_staging.py
@@ -185,6 +185,28 @@ class TestWorkingCopy(TestCase):
         self.assertEquals('The first one', bl_page.downloads.one.Title())
         self.assertEquals(['one', 'three'], bl_page.downloads.objectIds())
 
+    @browsing
+    def test_internal_links_to_files_in_filelistingblocks_are_synced(self, browser):
+        bl_page = create(Builder('sl content page').titled(u'Page'))
+        wc_page = IStaging(bl_page).create_working_copy(self.portal)
+
+        listingblock = create(Builder('sl listingblock').titled(u'Downloads').within(wc_page))
+        file1 = create(Builder('file').titled(u'One').within(listingblock))
+
+        create(Builder('sl textblock').titled(u'Link on file').within(wc_page)
+               .having(text=RichTextValue(u'''
+<p>
+  <a class="internal-link" href="resolveuid/{0}">One</a>
+</p>
+                            '''.format(IUUID(file1)).strip())))
+
+        IStaging(wc_page).apply_working_copy()
+
+        transaction.commit()
+        self.assertEquals(
+            'resolveuid/{}'.format(IUUID(self.portal.page.downloads.one)),
+            browser.login().visit(self.portal.page).css('a.internal-link').first.attrib['href'])
+
     def test_childrens_children_order_is_preserved(self):
         bl_page = create(Builder('sl content page').titled(u'Page'))
         bl_dow = create(Builder('sl listingblock').titled(u'Downloads')
@@ -248,7 +270,7 @@ class TestWorkingCopy(TestCase):
         self.assertEquals(
             {'default': [{'cols': [{'blocks': [
                 {'uid': 'baseline000000000000000000000002'},
-                {'uid': 'applying000000000000000000000001'}]}]}]},
+                {'uid': 'editing0000000000000000000000001'}]}]}]},
             IPageConfiguration(baseline).load())
 
     def test_sl_block_state_is_copied_when_applying(self):
@@ -311,7 +333,7 @@ class TestWorkingCopy(TestCase):
 <p>
   <a class="internal-link" href="resolveuid/baseline000000000000000000000001">One</a>
   <a class="internal-link" href="resolveuid/baseline000000000000000000000002">Two</a>
-  <a class="internal-link" href="resolveuid/apply000000000000000000000000001">Three</a>
+  <a class="internal-link" href="resolveuid/editing0000000000000000000000001">Three</a>
 </p>
         '''.strip(), bl_page.toc.text.raw.strip())
 

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -11,3 +11,4 @@ six = 1.12.0
 collective.geo.openlayers = <4a
 collective.geo.mapwidget = <3a
 geopy=1.23.0
+Products.GenericSetup = <1.8.11


### PR DESCRIPTION
This preserves the UUIDS and internal links created within the working
copy are still working.

The major change here is, that if the content gets newly created in the working copy. The UUID will be preserved, since the content gets moved the target page instead of copied over. 