### PR TITLE
Move objects to the target if they are created within the working copy.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,6 +7,9 @@ Changelog
 
 - Fix compatibility with plone.formwidget.namedfile 2.0.10+ (included in Plone 5.1.7+) [Nachtalb]
 
+- Staging: Move instead of copy blocks, which were created in the working copy, in
+  order to preserve the UID. Otherwise internal links within the working copy no longer work. [mathias.leimgruber]
+
 
 2.7.13 (2020-10-01)
 -------------------

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -296,6 +296,7 @@ class Staging(object):
         uuid_map = uuid_map or {}
         uuid_map[IUUID(source)] = IUUID(target)
         target_children_map = {IUUID(obj): obj for obj in self._get_children(target, condition)}
+        source_ids = source.objectIds()
         self._copy_field_values(source, target)
         self._purge_scales(target)
         self._update_simplelayout_block_state(source, target)
@@ -306,10 +307,10 @@ class Staging(object):
                 target_child = target_children_map.pop(target_uid)
                 self._apply_children(source_child, target_child, uuid_map=uuid_map)
             else:
-                target_child = self._copy_new_obj(source_child, target)
+                target_child = self._move_new_obj(source_child, target)
                 uuid_map[IUUID(source_child)] = IUUID(target_child)
 
-        target.moveObjectsToTop(source.objectIds())
+        target.moveObjectsToTop(source_ids)
         target.manage_delObjects(map(methodcaller('getId'), target_children_map.values()))
         return uuid_map
 
@@ -427,8 +428,8 @@ class Staging(object):
         for schema in getAdditionalSchemata(portal_type=portal_type):
             yield schema
 
-    def _copy_new_obj(self, obj, new_parent):
-        clipboard = aq_parent(aq_inner(obj)).manage_copyObjects([obj.getId()])
+    def _move_new_obj(self, obj, new_parent):
+        clipboard = aq_parent(aq_inner(obj)).manage_cutObjects([obj.getId()])
         info = new_parent.manage_pasteObjects(clipboard)
         return new_parent.get(info[0]['new_id'])
 

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -19,3 +19,4 @@ collective.z3cform.colorpicker = 1.4
 collective.z3cform.mapwidget = 2.1
 collective.z3cform.datagridfield = 1.4.0
 geopy = 1.23.0
+Products.GenericSetup = <1.8.11


### PR DESCRIPTION
This preserves the UUIDS and internal links created within the working
copy are still working.

Port from #657 