### PR TITLE
Update page config is recursively

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Fix compatibility with plone.formwidget.namedfile 2.0.10+ (included in Plone 5.1.7+) [Nachtalb]
+- Fix broken page configuration on copy paste for child pages [Nachtalb]
 
 
 2.7.13 (2020-10-01)


### PR DESCRIPTION
Only updating the configuration of the directly copied page leads to broken page configurations and thus all blocks are thrown into the default slot which should not happen.