### PR TITLE
Fix compatibility with Plone 5.1.7+

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.14 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix compatibility with plone.formwidget.namedfile 2.0.10+ (included in Plone 5.1.7+) [Nachtalb]
 
 
 2.7.13 (2020-10-01)

--- a/ftw/simplelayout/images/limits/validators.py
+++ b/ftw/simplelayout/images/limits/validators.py
@@ -1,10 +1,11 @@
 from ftw.simplelayout import _
-from ftw.simplelayout.images.interfaces import IImageLimits
 from ftw.simplelayout.images.interfaces import IImageLimitValidatorMessages
+from ftw.simplelayout.images.interfaces import IImageLimits
 from ftw.simplelayout.images.limits.limits import Limits
 from z3c.form import validator
-from zope.interface import implementer
+from z3c.form.interfaces import NOT_CHANGED
 from zope.interface import Invalid
+from zope.interface import implementer
 
 
 class LimitValidatorMessages(object):
@@ -118,6 +119,8 @@ class ImageLimitValidator(validator.SimpleFieldValidator):
         self._validate_hard_limit(value)
 
     def _validate_hard_limit(self, value):
+        if value == NOT_CHANGED:
+            value = getattr(self.context, self.field.getName())
         if not self._validate_limit_for('hard', value):
             raise Invalid(self.validator_messages.limit_not_satisfied_message(
                 'hard', self.identifier, value))


### PR DESCRIPTION
> plone.formwidget.namedfile
> 2.0.10 (2019-12-11)
> Bug fixes:
> 
> - set widget value to z3c.form.interfaces.NOT_CHANGED when the user selects ‘Keep Existing File’ in the widget, so z3c.form understands the field has not changed [flipmcf] (#41)