### PR TITLE
Fix youtube video integration

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.26.7 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix Videoblock YouTube integration [Nachtalb]
 
 
 1.26.6 (2020-10-21)

--- a/ftw/simplelayout/browser/resources/videoblock.js
+++ b/ftw/simplelayout/browser/resources/videoblock.js
@@ -12,7 +12,7 @@
   function resizeAll() { $.map($(".sl-youtube-video"), resizeYoutubePlayer); }
 
   function onPlayerReady(player) {
-    var iframe = player.target.f;
+    var iframe = player.target.getIframe();
 
     ratios[iframe.id] = ratios[iframe.id] || iframe.height/iframe.width;
 


### PR DESCRIPTION
We used an internal API endpoint that can change without preliminary notice. This is exactly what happened. So now we use the correct official endpoint instead.