### PR TITLE
Working copy BugFix: Reindex modified children, since the value may have changed

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.26.7 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Working copy BugFix: Reindex modified children, since the value may have changed. [mathias.leimgruber]
 
 
 1.26.6 (2020-10-21)

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -309,6 +309,7 @@ class Staging(object):
 
         target.moveObjectsToTop(source_ids)
         target.manage_delObjects(map(methodcaller('getId'), target_children_map.values()))
+        target.reindexObject()
         return uuid_map
 
     def _update_simplelayout_page_state(self, working_copy, baseline, uuid_map):


### PR DESCRIPTION
This happens for example if a file within a listingblock gets modified. 

The _copy_field_values method applies changes from the source to the target but never triggers a reindex.
But fields like Title, SearchableText might have changed and need a reindex. 