### PR TITLE
Working copy BugFix: Reindex modified children, since the value may have changed

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.7.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Working copy BugFix: Reindex modified children, since the value may have changed. [mathias.leimgruber]
 
 
 2.7.16 (2020-12-10)

--- a/ftw/simplelayout/staging/staging.py
+++ b/ftw/simplelayout/staging/staging.py
@@ -312,6 +312,7 @@ class Staging(object):
 
         target.moveObjectsToTop(source_ids)
         target.manage_delObjects(map(methodcaller('getId'), target_children_map.values()))
+        target.reindexObject()
         return uuid_map
 
     def _update_simplelayout_page_state(self, working_copy, baseline, uuid_map):


### PR DESCRIPTION
See #668 for details. 