### PR TITLE
Aliasblock Remove explicit dependency on sl contenttypes.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.26.11 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Aliasblock Remove explicit dependency on sl contenttypes. [mathias.leimgruber]
 
 
 1.26.10 (2020-12-16)

--- a/ftw/simplelayout/aliasblock/profiles/default/metadata.xml
+++ b/ftw/simplelayout/aliasblock/profiles/default/metadata.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
 <metadata>
   <dependencies>
-    <dependency>profile-ftw.simplelayout.contenttypes:default</dependency>
   </dependencies>
 </metadata>


### PR DESCRIPTION
To have this as an explicit dependency makes it really hard to install the Aliasblock after SL has been already installed, since it would apply the whole contenttypes configuration again. 

In real world the SL contenttypes is anyway always installed, otherwise there would be no ContentPage to even add a AliasBlock. 

This change makes it easy to add the aliasblock and its config as an update    to a existing site. 