### PR TITLE
Fix youtube video integration BACKPORT 2.0.x

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix Videoblock YouTube integration [Nachtalb]
 
 
 2.0.2 (2019-05-17)

--- a/ftw/simplelayout/browser/resources/videoblock.js
+++ b/ftw/simplelayout/browser/resources/videoblock.js
@@ -12,7 +12,7 @@
   function resizeAll() { $.map($(".sl-youtube-video"), resizeYoutubePlayer); }
 
   function onPlayerReady(player) {
-    var iframe = player.target.a;
+    var iframe = player.target.getIframe();
 
     ratios[iframe.id] = ratios[iframe.id] || iframe.height/iframe.width;
 

--- a/test-javascript.cfg
+++ b/test-javascript.cfg
@@ -1,2 +1,5 @@
 [buildout]
 extends = https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/test-javascript.cfg
+
+[versions]
+setuptools = <45.0

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -7,7 +7,6 @@ package-name = ftw.simplelayout
 test-egg = ftw.simplelayout [tests, contenttypes, mapblock, plone4]
 
 [versions]
-six = 1.9.0
 collective.geo.behaviour = 1.2
 collective.geo.bundle = 2.3
 collective.geo.contentlocations = 3.1

--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -7,7 +7,6 @@ package-name = ftw.simplelayout
 test-egg = ftw.simplelayout [tests, contenttypes, mapblock]
 
 [versions]
-six = 1.9.0
 ftw.upgrade = 2.9.0
 ftw.builder = 1.11.1
 ftw.theming = 2.0.0


### PR DESCRIPTION
Tests fail due to updates of other packages. As this is meant for an older Plone 4.3 policy which already works as is with 2.0.2 I don't deem it necessary to look into those dependency issues for this backport.  