### PR TITLE
Check all incoming references upon block deletion. This includes AliasBlocks

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -6,6 +6,7 @@ Changelog
 -------------------
 
 - Aliasblock Remove explicit dependency on sl contenttypes. [mathias.leimgruber]
+- Check all incoming references upon block deletion. This includes AliasBlocks. [mathias.leimgruber]
 
 
 2.7.16 (2020-12-10)

--- a/ftw/simplelayout/aliasblock/contents/aliasblock.py
+++ b/ftw/simplelayout/aliasblock/contents/aliasblock.py
@@ -103,3 +103,10 @@ alsoProvides(IAliasBlockSchema, IFormFieldProvider)
 
 class AliasBlock(Item):
     implements(IAliasBlock)
+
+
+    def Title(self):
+        if self.alias.isBroken():
+            return 'AliasBlock: "No target"'
+        return 'AliasBlock: "{}"'.format(self.alias.to_object.Title())
+

--- a/ftw/simplelayout/browser/ajax/delete_blocks.py
+++ b/ftw/simplelayout/browser/ajax/delete_blocks.py
@@ -3,12 +3,23 @@ from ftw.simplelayout.utils import IS_PLONE_5
 from plone import api
 from plone.app.uuid.utils import uuidToObject
 from plone.uuid.interfaces import IUUID
-from Products.CMFPlone.utils import isLinked
 from Products.CMFPlone.utils import transaction_note
 from Products.Five.browser import BrowserView
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zExceptions import BadRequest
 import json
+
+
+if IS_PLONE_5:
+    from plone.app.linkintegrity.utils import getIncomingLinks
+
+    def isLinked(obj):
+        # Important - Check all incoming references, not just tinymce relations
+        for it in getIncomingLinks(obj=obj, intid=None, from_attribute=None):
+            return True
+        return False
+else:
+    from Products.CMFPlone.utils import isLinked
 
 
 class DeleteBlocks(BrowserView):


### PR DESCRIPTION
Also add a better title for aliasBlocks.

The incoming ref change only works with Plone 5.
Since the link integrity check in plone 4 does not support DX relations (zc.relations)