### PR TITLE
Make rendering the aliasblock add/edit form viewlet more safe

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.27.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make rendering the aliasblock add/edit form viewlet more safe. [mathias.leimgruber]
 
 
 1.27.0 (2021-03-05)

--- a/ftw/simplelayout/aliasblock/browser/viewlet.py
+++ b/ftw/simplelayout/aliasblock/browser/viewlet.py
@@ -1,14 +1,22 @@
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from collective.geo.settings.interfaces import IGeoSettings
 from ftw.simplelayout.aliasblock.contents.interfaces import IAliasBlock
 from plone import api
 from plone.app.layout.viewlets.common import ViewletBase
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from zope.component import queryMultiAdapter
+from plone.registry.interfaces import IRegistry
+from zope.component import getUtility
 
 
 def geo_settings_installed():
     version = api.portal.get().portal_setup.getLastVersionForProfile('collective.geo.settings:default')
-    return version != 'unknown'
 
+    has_settings = True
+    try:
+        getUtility(IRegistry).forInterface(IGeoSettings)
+    except KeyError:
+        has_settings = False
+
+    return version != 'unknown' and has_settings
 
 
 class AliasBlockFormViewlet(ViewletBase):
@@ -19,5 +27,4 @@ class AliasBlockFormViewlet(ViewletBase):
 
         is_aliasblock = IAliasBlock.providedBy(self.context)
         is_aliasblock_add_form = self.view.__name__ == 'ftw.simplelayout.AliasBlock'
-
         self.do_render_mapwidget = (is_aliasblock or is_aliasblock_add_form) and geo_settings_installed()


### PR DESCRIPTION
This case happens if the package once was installed and not properly uninstalled.
The package might be still in the path but has some traces all over.