### PR TITLE
Make sure there are no harmful css classes withing the content of a TextBlock.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 2.8.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make sure there are no harmful css classes withing the content of a TextBlock. [mathias.leimgruber]
 
 
 2.8.2 (2021-07-20)

--- a/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
+++ b/ftw/simplelayout/contenttypes/browser/templates/textblock.pt
@@ -37,7 +37,7 @@
           <div class="image-caption" tal:content="context/image_caption" />
         </div>
       </tal:image>
-      <div tal:replace="structure here/text/output | nothing" />
+      <div tal:replace="structure view/get_sl_safe_markup | nothing" />
       <p tal:condition="python: view.can_add and not (here.image or here.text or here.title)"
          i18n:translate="">This block is empty.</p>
     </metal:BODY>

--- a/ftw/simplelayout/contenttypes/browser/textblock.py
+++ b/ftw/simplelayout/contenttypes/browser/textblock.py
@@ -15,6 +15,17 @@ from zope.component import queryMultiAdapter
 from zope.i18n import translate
 
 
+# Order is important
+DISALLOWED_CSS_CLASSES =[
+    'sl-layout-content',
+    'sl-layout',
+    'sl-block',
+    'sl-columns',
+    'sl-column',
+    'sl-simplelayout',
+]
+
+
 class TextBlockView(BaseBlock):
 
     template = ViewPageTemplateFile('templates/textblock.pt')
@@ -162,3 +173,15 @@ class TextBlockView(BaseBlock):
 
     def show_limit_indicator(self):
         return self.can_add
+
+    def get_sl_safe_markup(self):
+        # XXX: This should be implemented as a portal transform, in order to
+        # use the right tool for it and get caching for free.
+        text = self.context.text
+
+        if text:
+            safe_html = text.output
+            for css_class in DISALLOWED_CSS_CLASSES:
+                safe_html = safe_html.replace(css_class, '')
+            return safe_html
+        return ''

--- a/ftw/simplelayout/tests/test_textblock_view.py
+++ b/ftw/simplelayout/tests/test_textblock_view.py
@@ -458,3 +458,15 @@ class TestTextBlockRendering(TestCase):
         browser.open_html(block_view())
 
         self.assertNotEqual(browser.css('.sl-image .colorboxLink').first.get('href'), url)
+
+    @browsing
+    def test_if_harmeful_css_classes_are_removed(self, browser):
+        page = create(Builder('sl content page'))
+        block = create(Builder('sl textblock')
+                       .having(text=RichTextValue(
+                           '<p id="test-textblock" class="anotherclass sl-simplelayout sl-layout">The text</p>'))
+                       .within(page))
+
+        browser.login().visit(page)
+        self.assertNotIn('sl-simplelayout', browser.css('#test-textblock').first.attrib['class'])
+        self.assertNotIn('sl-layout', browser.css('#test-textblock').first.attrib['class'])


### PR DESCRIPTION
I happens sometimes that user copy / paste text from the same website, including the markup.
Which may result in nested simplelayout structures within the TextBlock. 

This is to a certain degree OK, but might be harmful if not intended. 

This PR removes those harmful css classes before rendering the content of a TextBlock.

It's a quickfix and not yet the best solution --> See hint in code. 